### PR TITLE
Feature: 악세사리 상세 정보 페이지 개선

### DIFF
--- a/lib/features/rental/views/rental_detail_view.dart
+++ b/lib/features/rental/views/rental_detail_view.dart
@@ -114,6 +114,12 @@ class _RentalDetailViewState extends State<RentalDetailView> {
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
+                          const SizedBox(height: 8),
+                          Text(
+                            widget.accessory.category.name,
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                          const SizedBox(height: 8),
                           Text(
                             widget.accessory.name,
                             style: Theme.of(context).textTheme.headlineSmall,
@@ -122,6 +128,11 @@ class _RentalDetailViewState extends State<RentalDetailView> {
                           Text(
                             '${widget.accessory.pricePerHour}원/시간',
                             style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            widget.accessory.description,
+                            style: Theme.of(context).textTheme.bodyMedium,
                           ),
                           const SizedBox(height: 24),
                           Row(
@@ -156,182 +167,6 @@ class _RentalDetailViewState extends State<RentalDetailView> {
                                 ),
                               ),
                             ],
-                          ),
-                          const SizedBox(height: 24),
-                          Text(
-                            '대여 시간',
-                            style: Theme.of(context).textTheme.titleMedium,
-                          ),
-                          const SizedBox(height: 8),
-                          Container(
-                            padding: const EdgeInsets.all(16),
-                            decoration: BoxDecoration(
-                              color: Colors.white,
-                              borderRadius: BorderRadius.circular(8),
-                              border: Border.all(
-                                color: Colors.grey[300]!,
-                              ),
-                            ),
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    Text(
-                                      '선택된 시간',
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .titleSmall,
-                                    ),
-                                    Text(
-                                      '$_selectedHours시간',
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .titleSmall
-                                          ?.copyWith(
-                                            color:
-                                                Theme.of(context).primaryColor,
-                                          ),
-                                    ),
-                                  ],
-                                ),
-                                const SizedBox(height: 16),
-                                Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    IconButton(
-                                      onPressed: _selectedHours > 1
-                                          ? () {
-                                              setState(() {
-                                                _selectedHours--;
-                                              });
-                                              // 시간 변경 시 쿠키 업데이트
-                                              _storageService.setInt(
-                                                'selected_rental_duration',
-                                                _selectedHours,
-                                              );
-                                              _storageService.setInt(
-                                                'selected_price',
-                                                widget.accessory.pricePerHour *
-                                                    _selectedHours,
-                                              );
-                                            }
-                                          : null,
-                                      icon: const Icon(
-                                          Icons.remove_circle_outline),
-                                    ),
-                                    Expanded(
-                                      child: Slider(
-                                        value: _selectedHours.toDouble(),
-                                        min: 1,
-                                        max: 24,
-                                        divisions: 23,
-                                        label: '$_selectedHours시간',
-                                        onChanged: (value) {
-                                          setState(() {
-                                            _selectedHours = value.toInt();
-                                          });
-                                          // 시간 변경 시 쿠키 업데이트
-                                          _storageService.setInt(
-                                            'selected_rental_duration',
-                                            _selectedHours,
-                                          );
-                                          _storageService.setInt(
-                                            'selected_price',
-                                            widget.accessory.pricePerHour *
-                                                _selectedHours,
-                                          );
-                                        },
-                                      ),
-                                    ),
-                                    IconButton(
-                                      onPressed: _selectedHours < 24
-                                          ? () {
-                                              setState(() {
-                                                _selectedHours++;
-                                              });
-                                              // 시간 변경 시 쿠키 업데이트
-                                              _storageService.setInt(
-                                                'selected_rental_duration',
-                                                _selectedHours,
-                                              );
-                                              _storageService.setInt(
-                                                'selected_price',
-                                                widget.accessory.pricePerHour *
-                                                    _selectedHours,
-                                              );
-                                            }
-                                          : null,
-                                      icon:
-                                          const Icon(Icons.add_circle_outline),
-                                    ),
-                                  ],
-                                ),
-                                const SizedBox(height: 16),
-                                Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    Text(
-                                      '시간당 가격',
-                                      style: TextStyle(
-                                        color: Colors.grey[600],
-                                      ),
-                                    ),
-                                    Text(
-                                      '${widget.accessory.pricePerHour}원',
-                                      style: TextStyle(
-                                        color: Colors.grey[600],
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                                const SizedBox(height: 8),
-                                Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    Text(
-                                      '총 대여 시간',
-                                      style: TextStyle(
-                                        color: Colors.grey[600],
-                                      ),
-                                    ),
-                                    Text(
-                                      '$_selectedHours시간',
-                                      style: TextStyle(
-                                        color: Colors.grey[600],
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                                const SizedBox(height: 8),
-                                const Divider(),
-                                const SizedBox(height: 8),
-                                Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    const Text(
-                                      '총 결제 금액',
-                                      style: TextStyle(
-                                        fontWeight: FontWeight.bold,
-                                      ),
-                                    ),
-                                    Text(
-                                      '${widget.accessory.pricePerHour * _selectedHours}원',
-                                      style: TextStyle(
-                                        color: Theme.of(context).primaryColor,
-                                        fontWeight: FontWeight.bold,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            ),
                           ),
                           const SizedBox(height: 24),
                           Text(
@@ -408,15 +243,6 @@ class _RentalDetailViewState extends State<RentalDetailView> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  Text(
-                    '총 결제 금액: ${widget.accessory.pricePerHour * _selectedHours}원',
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          color: Theme.of(context).primaryColor,
-                          fontWeight: FontWeight.bold,
-                        ),
-                    textAlign: TextAlign.right,
-                  ),
-                  const SizedBox(height: 8),
                   ElevatedButton(
                     onPressed: (_selectedStation == null || _quantity == 0)
                         ? null

--- a/lib/features/rental/views/rental_detail_view.dart
+++ b/lib/features/rental/views/rental_detail_view.dart
@@ -6,6 +6,7 @@ import '../../../data/models/accessory.dart';
 import '../../../data/models/station.dart';
 import '../../../app/routes.dart';
 import '../../../data/repositories/station_repository.dart';
+import 'dart:math'; // 임시 데이터 생성용
 
 class RentalDetailView extends StatefulWidget {
   final Accessory accessory;
@@ -25,11 +26,14 @@ class _RentalDetailViewState extends State<RentalDetailView> {
   final _storageService = StorageService.instance;
   Station? _selectedStation;
   int _selectedHours = 1;
+  late final int _quantity; // 악세사리 수량
 
   @override
   void initState() {
     super.initState();
     _selectedStation = widget.station;
+    // 임시 데이터: 0~5개 랜덤 생성
+    _quantity = Random().nextInt(6);
 
     // 초기 대여 시간 쿠키 생성
     _storageService.setInt('selected_rental_duration', _selectedHours);
@@ -119,14 +123,39 @@ class _RentalDetailViewState extends State<RentalDetailView> {
                             '${widget.accessory.pricePerHour}원/시간',
                             style: Theme.of(context).textTheme.titleMedium,
                           ),
-                          const SizedBox(height: 16),
-                          Text(
-                            widget.accessory.isAvailable ? '대여 가능' : '대여 불가',
-                            style: TextStyle(
-                              color: widget.accessory.isAvailable
-                                  ? Theme.of(context).primaryColor
-                                  : Colors.grey,
-                            ),
+                          const SizedBox(height: 24),
+                          Row(
+                            children: [
+                              Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 12,
+                                  vertical: 6,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: _selectedStation == null
+                                      ? Colors.grey[200]
+                                      : _quantity > 0
+                                          ? Theme.of(context)
+                                              .primaryColor
+                                              .withOpacity(0.1)
+                                          : Colors.grey[200],
+                                  borderRadius: BorderRadius.circular(4),
+                                ),
+                                child: Text(
+                                  _selectedStation == null
+                                      ? '스테이션 선택 후 수량 확인'
+                                      : '남은 수량: $_quantity개',
+                                  style: TextStyle(
+                                    color: _selectedStation == null
+                                        ? Colors.grey[600]
+                                        : _quantity > 0
+                                            ? Theme.of(context).primaryColor
+                                            : Colors.grey[600],
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                              ),
+                            ],
                           ),
                           const SizedBox(height: 24),
                           Text(
@@ -202,7 +231,7 @@ class _RentalDetailViewState extends State<RentalDetailView> {
                                         divisions: 23,
                                         label: '$_selectedHours시간',
                                         onChanged: (value) {
-                                setState(() {
+                                          setState(() {
                                             _selectedHours = value.toInt();
                                           });
                                           // 시간 변경 시 쿠키 업데이트
@@ -389,7 +418,7 @@ class _RentalDetailViewState extends State<RentalDetailView> {
                   ),
                   const SizedBox(height: 8),
                   ElevatedButton(
-                    onPressed: _selectedStation == null
+                    onPressed: (_selectedStation == null || _quantity == 0)
                         ? null
                         : () async {
                             // 쿠키에 정보 저장
@@ -432,7 +461,11 @@ class _RentalDetailViewState extends State<RentalDetailView> {
                             }
                           },
                     child: Text(
-                      _selectedStation == null ? '스테이션을 선택해주세요' : 'QR 스캔하기',
+                      _selectedStation == null
+                          ? '스테이션을 선택해주세요'
+                          : _quantity == 0
+                              ? '현재 대여 불가능'
+                              : 'QR 스캔하기',
                     ),
                   ),
                 ],


### PR DESCRIPTION
## 이슈 번호
#3 , #12
## 작업 내용
### 수량 관련 기능 추가:
- _quantity 변수를 추가하여 악세사리 수량을 저장
- initState()에서 0~5 사이의 랜덤 수량을 생성
- 기존의 '대여 가능' 문구 대신 수량을 표시하는 UI 추가
### 수량 표시 UI:
- 스테이션 미선택:  "스테이션 선택 후 수량 확인" 표시
- 스테이션 선택
    - 수량이 있는 경우: 테마 컬러로 표시
    - 수량이 0인 경우: 회색으로 표시
### 버튼 상태 및 텍스트 변경:
- 수량이 0인 경우 버튼 비활성화
- 버튼 텍스트를 상황에 따라 다르게 표시:
    - 스테이션 미선택: "스테이션을 선택해주세요"
    - 수량 0개: "현재 대여 불가능"
    - 정상 상태: "QR 스캔하기"
### 악세사리 상세 정보 필드 수정
- 카테고리 및 설명 필드 추가
- 불필요한 부분 삭제 (시간 선택, 결제 금액)
<hr>
실제 데이터 연동 시에는 _quantity 변수만 실제 데이터로 교체. <br>
현재는 임시로 Random()을 사용하여 0~5 사이의 랜덤 값을 생성하도록 구현