### PR TITLE
Feature: 회원정보 페이지 개선 및 대여 내역 분리

### DIFF
--- a/lib/data/repositories/rental_repository.dart
+++ b/lib/data/repositories/rental_repository.dart
@@ -168,6 +168,7 @@ class RentalRepository implements BaseRepository<Rental> {
 
   Future<List<Rental>> getRecentRentals() async {
     await Future.delayed(const Duration(seconds: 1));
+
     return [
       Rental(
         id: 'R3',
@@ -176,10 +177,12 @@ class RentalRepository implements BaseRepository<Rental> {
         stationId: 'S1',
         accessoryName: '노트북 고출력 충전기',
         stationName: '강남역점',
+        returnStationId: 'S2',
+        returnStationName: '홍대입구역점',
         totalPrice: 2000,
-        status: RentalStatus.completed,
-        createdAt: DateTime.now().subtract(const Duration(days: 1)),
-        updatedAt: DateTime.now().subtract(const Duration(days: 1)),
+        status: RentalStatus.overdue,
+        createdAt: DateTime.now().subtract(const Duration(days: 1, hours: 2)),
+        updatedAt: DateTime.now().subtract(const Duration(hours: 1)),
       ),
       Rental(
         id: 'R4',
@@ -188,6 +191,8 @@ class RentalRepository implements BaseRepository<Rental> {
         stationId: 'S2',
         accessoryName: '멀티 독 (Type-C)',
         stationName: '홍대입구역점',
+        returnStationId: 'S1',
+        returnStationName: '강남역점',
         totalPrice: 2000,
         status: RentalStatus.completed,
         createdAt: DateTime.now().subtract(const Duration(days: 2)),
@@ -200,8 +205,10 @@ class RentalRepository implements BaseRepository<Rental> {
         stationId: 'S3',
         accessoryName: '휴대폰용 보조배터리',
         stationName: '명동점',
+        returnStationId: 'S4',
+        returnStationName: '여의도역점',
         totalPrice: 1500,
-        status: RentalStatus.completed,
+        status: RentalStatus.overdueCompleted,
         createdAt: DateTime.now().subtract(const Duration(days: 3)),
         updatedAt: DateTime.now().subtract(const Duration(days: 3)),
       ),

--- a/lib/features/mypage/views/edit_profile_view.dart
+++ b/lib/features/mypage/views/edit_profile_view.dart
@@ -12,7 +12,6 @@ class EditProfileView extends StatefulWidget {
 
 class _EditProfileViewState extends State<EditProfileView> {
   final _nameController = TextEditingController();
-  final _phoneController = TextEditingController();
   bool _isLoading = false;
   String? _error;
 
@@ -22,24 +21,21 @@ class _EditProfileViewState extends State<EditProfileView> {
     final user = AuthService.instance.currentUser;
     if (user != null) {
       _nameController.text = user.name;
-      _phoneController.text = user.phoneNumber;
     }
   }
 
   @override
   void dispose() {
     _nameController.dispose();
-    _phoneController.dispose();
     super.dispose();
   }
 
   Future<void> _save() async {
     final name = _nameController.text.trim();
-    final phone = _phoneController.text.trim();
 
-    if (name.isEmpty || phone.isEmpty) {
+    if (name.isEmpty) {
       setState(() {
-        _error = '모든 필드를 입력해주세요.';
+        _error = '닉네임을 입력해주세요.';
       });
       return;
     }
@@ -52,7 +48,7 @@ class _EditProfileViewState extends State<EditProfileView> {
     try {
       await AuthService.instance.updateProfile(
         name: name,
-        phoneNumber: phone,
+        phoneNumber: AuthService.instance.currentUser?.phoneNumber ?? '',
       );
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -134,24 +130,8 @@ class _EditProfileViewState extends State<EditProfileView> {
               TextField(
                 controller: _nameController,
                 decoration: InputDecoration(
-                  hintText: '이름',
-                  contentPadding: const EdgeInsets.all(16),
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(8),
-                    borderSide: const BorderSide(color: AppColors.lightGrey),
-                  ),
-                  enabledBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(8),
-                    borderSide: const BorderSide(color: AppColors.lightGrey),
-                  ),
-                ),
-              ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: _phoneController,
-                keyboardType: TextInputType.phone,
-                decoration: InputDecoration(
-                  hintText: '휴대폰 번호',
+                  labelText: '닉네임',
+                  hintText: '닉네임을 입력해주세요',
                   contentPadding: const EdgeInsets.all(16),
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(8),

--- a/lib/features/mypage/views/mypage_view.dart
+++ b/lib/features/mypage/views/mypage_view.dart
@@ -4,6 +4,8 @@ import '../../../core/constants/app_theme.dart';
 import '../../../core/services/auth_service.dart';
 import '../../../core/widgets/bottom_navigation_bar.dart';
 import '../../../app/routes.dart';
+import '../../../features/rental/views/active_rentals_view.dart';
+import '../../../features/rental/views/rental_history_view.dart';
 
 class MyPageView extends StatelessWidget {
   const MyPageView({super.key});
@@ -88,10 +90,14 @@ class MyPageView extends StatelessWidget {
                     Expanded(
                       child: TextButton.icon(
                         onPressed: () {
-                          Navigator.of(context).pushNamed(Routes.rentalHistory);
+                          Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (context) => const ActiveRentalsView(),
+                            ),
+                          );
                         },
-                        icon: const Icon(Icons.history),
-                        label: const Text('이용 내역'),
+                        icon: const Icon(Icons.access_time_filled),
+                        label: const Text('대여 현황'),
                       ),
                     ),
                     Container(
@@ -102,10 +108,14 @@ class MyPageView extends StatelessWidget {
                     Expanded(
                       child: TextButton.icon(
                         onPressed: () {
-                          // TODO: 결제 수단 관리 페이지로 이동
+                          Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (context) => const RentalHistoryView(),
+                            ),
+                          );
                         },
-                        icon: const Icon(Icons.payment),
-                        label: const Text('결제 수단 관리'),
+                        icon: const Icon(Icons.receipt_long),
+                        label: const Text('대여 내역'),
                       ),
                     ),
                   ],

--- a/lib/features/rental/views/active_rentals_view.dart
+++ b/lib/features/rental/views/active_rentals_view.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import '../../../data/models/rental.dart';
+import '../../../data/repositories/rental_repository.dart';
+import '../../../core/constants/app_theme.dart';
+
+class ActiveRentalsView extends StatefulWidget {
+  const ActiveRentalsView({super.key});
+
+  @override
+  State<ActiveRentalsView> createState() => _ActiveRentalsViewState();
+}
+
+class _ActiveRentalsViewState extends State<ActiveRentalsView> {
+  final _rentalRepository = RentalRepository.instance;
+  List<Rental> _rentals = [];
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadRentals();
+  }
+
+  Future<void> _loadRentals() async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final rentals = await _rentalRepository.getActiveRentals();
+
+      setState(() {
+        _rentals = rentals;
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _isLoading = false;
+      });
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('대여 현황을 불러오는데 실패했습니다: $e')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('현재 대여 중'),
+        centerTitle: true,
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : RefreshIndicator(
+              onRefresh: _loadRentals,
+              child: _rentals.isEmpty
+                  ? const Center(
+                      child: Text('현재 대여 중인 물품이 없습니다'),
+                    )
+                  : ListView.builder(
+                      padding: const EdgeInsets.all(16.0),
+                      itemCount: _rentals.length,
+                      itemBuilder: (context, index) {
+                        return _buildRentalCard(_rentals[index]);
+                      },
+                    ),
+            ),
+    );
+  }
+
+  Widget _buildRentalCard(Rental rental) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8.0),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(
+                  child: Text(
+                    rental.accessoryName,
+                    style: AppTheme.titleSmall,
+                  ),
+                ),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 4,
+                  ),
+                  decoration: BoxDecoration(
+                    color: Colors.blue.withOpacity(0.1),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: const Text(
+                    '대여 중',
+                    style: TextStyle(
+                      color: Colors.blue,
+                      fontSize: 12,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text('대여 스테이션: ${rental.stationName}'),
+            const SizedBox(height: 4),
+            Text(
+              '대여일시: ${rental.createdAt.toString().substring(0, 16)}',
+            ),
+            const SizedBox(height: 4),
+            Text('대여 시간: ${rental.formattedRentalTime}'),
+            const SizedBox(height: 4),
+            Text('결제 금액: ${rental.totalPrice}원'),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () {
+                  // TODO: 연장 기능 구현
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('준비 중인 기능입니다.')),
+                  );
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.blue.withOpacity(0.1),
+                  foregroundColor: Colors.blue,
+                  elevation: 0,
+                ),
+                child: const Text('연장하기'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
x

## 🛠️ 작업 내용
### 1. 회원정보 수정페이지

> - 전화번호 필드 제거

### 2. 회원정보 페이지

> - 대여현황, 대여내역 이동 네비게이션 생성
> 	- 대여 현황 버튼 클릭 시 ActiveRentalsView로 이동
> 	- 대여 내역 버튼 클릭 시 RentalHistoryView로 이동

### 3. RentalHistoryView 수정

> - 대여 현황과 대여 내역 분리
> - 대여 현황
> 	- ActiveRentalsView 생성
> - 대여 내역
> 	- 연체 관련 정보와 버튼 추가

### 4. 디버깅용 데이터 수정

## 💬 To Other
API 연동은 아직 안 됨. 더미 데이터를 활용해 테스트 진행함.