### PR TITLE
Chore: PR 이벤트 Slack 알림 Workflow 설정

### DIFF
--- a/.github/workflows/pr-events-slack.yml
+++ b/.github/workflows/pr-events-slack.yml
@@ -1,0 +1,47 @@
+name: Slack Notification
+
+on:
+  pull_request:
+    types:
+      - opened
+      - closed
+      - synchronize
+    branches:
+      - main
+
+jobs:
+  slack_nofitication:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack Notification on PR Opened
+        if: github.event.action == 'opened'
+        uses: 8398a7/action-slack@v3
+        with:
+          status: success
+          author_name: 'bannabe-app'
+          fields: repo,eventName,ref,workflow,job
+          text: "🚀 *새로운 PR이 생성되었습니다!* \n👤 *작성자:* `${{ github.event.pull_request.user.login }}`\n📌 *제목:* `${{ github.event.pull_request.title }} (#${{ github.event.pull_request.number }})` \n🔗 *[PR 확인하기]:* ${{ github.event.pull_request.html_url }}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Send Slack Notification on PR Updated (New Commit)
+        if: github.event.action == 'synchronize'
+        uses: 8398a7/action-slack@v3
+        with:
+          status: success
+          author_name: 'bannabe-app'
+          fields: repo,eventName,ref,workflow,job
+          text: "📝 *PR에 새로운 Commit이 추가되었습니다!* \n👤 *작성자:* `${{ github.event.pull_request.user.login }}`\n📌 *제목:* `${{ github.event.pull_request.title }} (#${{ github.event.pull_request.number }})` \n🔗 *[PR 확인하기]:* ${{ github.event.pull_request.html_url }}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Send Slack Notification on PR Merged
+        if: github.event.action == 'closed' && github.event.pull_request.merged == true
+        uses: 8398a7/action-slack@v3
+        with:
+          status: success
+          author_name: 'bannabe-app'
+          fields: repo,eventName,ref,workflow,job
+          text: "🎉 *PR이 Merge되었습니다!* \n👤 *작성자:* `${{ github.event.pull_request.user.login }}`\n✅ *Merge한 사람:* `${{ github.actor }}`\n📌 *제목:* `${{ github.event.pull_request.title }} (#${{ github.event.pull_request.number }})` \n🔗 *[Merge PR 확인하기]*: ${{ github.event.pull_request.html_url }}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
이슈 X


## 🛠️ 작업 내용
### PR 관련 Slack 알림 생성 Workflow 설정
`pr-events-slack.yml`로 PR 관련 이벤트 발생 시 `반나비-개발`채널로 메시지를 전송합니다.
알림 메시지 생성 트리거는 다음과 같습니다.
1. PR 생성
2. PR에 새로운 Commit 추가
3. PR 병합

**[참고 이미지]**
![image](https://github.com/user-attachments/assets/4db62d80-dad7-4cd8-b2dd-12dc427f4e88)


## 💬 To Other
금일 오전 중으로 @pyqvv @minwoojoo 슬랙 `반나비-개발` 채널 초대 예정입니다.