### PR TITLE
Refactor: PR 알림 workflow 수정

### DIFF
--- a/.github/workflows/pr-events-slack.yml
+++ b/.github/workflows/pr-events-slack.yml
@@ -7,7 +7,9 @@ on:
       - closed
       - synchronize
     branches:
-      - main
+      - not/used
+
+# forked repository trigger workflow에서는 secrets를 사용할 수 없으므로 사용하지 않는 branch로 변경
 
 jobs:
   slack_nofitication:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
x


## 🛠️ 작업 내용
### PR 이벤트 workflow 수정
- Forked Repository에서 트리거된 Workflow에는 secrets 값이 전달되지 않습니다.
- 예전에도 이런 문제가 발생했었는데... 까먹고 다시 경험했습니다.
- Workflow는 이후에 사용하기 위해 남겨두겠습니다. 
- 트리거되는 브랜치를 `not/used`로 변경해 트리거될일 없도록 했습니다.

## 💬 To Other
리뷰어에게 남기고 싶은 말을 작성해주세요.