### PR TITLE
Chore: Slack Alert Workflow 활성화

### DIFF
--- a/.github/workflows/pr-events-slack.yml
+++ b/.github/workflows/pr-events-slack.yml
@@ -7,9 +7,7 @@ on:
       - closed
       - synchronize
     branches:
-      - not/used
-
-# forked repository trigger workflow에서는 secrets를 사용할 수 없으므로 사용하지 않는 branch로 변경
+      - main
 
 jobs:
   slack_nofitication:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
x


## 🛠️ 작업 내용
### Slack 알림 Workflow 활성화
- 프로젝트 작업 구조를 변경하였으므로, Workflow를 다시 활성화 했습니다.
- 앞으로 forked repo에서 작업 후, 원본 repo로 PR을 올리는 것이 아닌, 원본 repo를 clone 하여 작업합니다.
- `origin` remote를 forked repo 에서 원본 repo로 수정합니다.
- 대신 `main` 브랜치에 대한 Branch Protection Rule을 엄격하게 설정하였습니다.

## 💬 To Other
.