### PR TITLE
Feature: 사용자 정보 관련 API 연동 및 JWT 토큰 관리

### DIFF
--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -1,0 +1,135 @@
+import 'dart:io';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import '../../app/routes.dart';
+import 'token_service.dart';
+
+class ApiService {
+  static final ApiService _instance = ApiService._internal();
+  static ApiService get instance => _instance;
+
+  late final Dio _dio;
+  final String _baseUrl = 'http://10.0.2.2:8080/v1'; // 개발 환경 기본 URL
+
+  ApiService._internal() {
+    _dio = Dio(
+      BaseOptions(
+        baseUrl: _baseUrl,
+        connectTimeout: const Duration(seconds: 5),
+        receiveTimeout: const Duration(seconds: 10),
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+      ),
+    );
+
+    // 요청 인터셉터 설정
+    _dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) async {
+          // 액세스 토큰이 있으면 헤더에 추가
+          final accessToken = await TokenService.instance.getAccessToken();
+          if (accessToken != null) {
+            options.headers['Authorization'] = 'Bearer $accessToken';
+          }
+          return handler.next(options);
+        },
+        onError: (DioException error, handler) async {
+          // 401 에러 처리 (토큰 만료)
+          if (error.response?.statusCode == 401) {
+            // 리프레시 토큰이 있는지 확인
+            final refreshToken = await TokenService.instance.getRefreshToken();
+            if (refreshToken != null) {
+              try {
+                // 리프레시 토큰으로 새 액세스 토큰 요청
+                final response = await _dio.post(
+                  '/auth/refresh',
+                  data: {'refreshToken': refreshToken},
+                  options: Options(headers: {'Authorization': null}),
+                );
+
+                if (response.statusCode == 200) {
+                  // 새 토큰 저장
+                  await TokenService.instance.setTokens(
+                    accessToken: response.data['accessToken'],
+                    refreshToken: response.data['refreshToken'],
+                  );
+
+                  // 원래 요청 재시도
+                  final opts = error.requestOptions;
+                  final newAccessToken =
+                      await TokenService.instance.getAccessToken();
+                  opts.headers['Authorization'] = 'Bearer $newAccessToken';
+
+                  final newResponse = await _dio.fetch(opts);
+                  return handler.resolve(newResponse);
+                }
+              } catch (e) {
+                // 리프레시 토큰도 만료된 경우
+                await TokenService.instance.clearTokens();
+                _navigateToLogin();
+              }
+            } else {
+              // 리프레시 토큰이 없는 경우
+              _navigateToLogin();
+            }
+          }
+          return handler.next(error);
+        },
+      ),
+    );
+  }
+
+  // 로그인 페이지로 이동
+  void _navigateToLogin() {
+    final context = navigatorKey.currentContext;
+    if (context != null) {
+      Navigator.of(context).pushNamedAndRemoveUntil(
+        Routes.login,
+        (route) => false,
+      );
+    }
+  }
+
+  // 전역 NavigatorKey
+  static final GlobalKey<NavigatorState> navigatorKey =
+      GlobalKey<NavigatorState>();
+
+  // GET 요청
+  Future<Response> get(String path,
+      {Map<String, dynamic>? queryParameters}) async {
+    try {
+      return await _dio.get(path, queryParameters: queryParameters);
+    } on DioException {
+      rethrow;
+    }
+  }
+
+  // POST 요청
+  Future<Response> post(String path, {dynamic data}) async {
+    try {
+      return await _dio.post(path, data: data);
+    } on DioException {
+      rethrow;
+    }
+  }
+
+  // PUT 요청
+  Future<Response> put(String path, {dynamic data}) async {
+    try {
+      return await _dio.put(path, data: data);
+    } on DioException {
+      rethrow;
+    }
+  }
+
+  // DELETE 요청
+  Future<Response> delete(String path, {dynamic data}) async {
+    try {
+      return await _dio.delete(path, data: data);
+    } on DioException {
+      rethrow;
+    }
+  }
+}

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -100,7 +100,9 @@ class ApiService {
   Future<Response> get(String path,
       {Map<String, dynamic>? queryParameters}) async {
     try {
-      return await _dio.get(path, queryParameters: queryParameters);
+      final options = await _getRequestOptions();
+      return await _dio.get(path,
+          queryParameters: queryParameters, options: options);
     } on DioException {
       rethrow;
     }
@@ -109,7 +111,8 @@ class ApiService {
   // POST 요청
   Future<Response> post(String path, {dynamic data}) async {
     try {
-      return await _dio.post(path, data: data);
+      final options = await _getRequestOptions();
+      return await _dio.post(path, data: data, options: options);
     } on DioException {
       rethrow;
     }
@@ -118,7 +121,8 @@ class ApiService {
   // PUT 요청
   Future<Response> put(String path, {dynamic data}) async {
     try {
-      return await _dio.put(path, data: data);
+      final options = await _getRequestOptions();
+      return await _dio.put(path, data: data, options: options);
     } on DioException {
       rethrow;
     }
@@ -127,9 +131,39 @@ class ApiService {
   // DELETE 요청
   Future<Response> delete(String path, {dynamic data}) async {
     try {
-      return await _dio.delete(path, data: data);
+      final options = await _getRequestOptions();
+      return await _dio.delete(path, data: data, options: options);
     } on DioException {
       rethrow;
     }
+  }
+
+  // PATCH 요청
+  Future<Response> patch(String path, {dynamic data}) async {
+    try {
+      print('ApiService PATCH 요청:');
+      print('URL: $_baseUrl$path');
+      print('Data: $data');
+
+      final options = await _getRequestOptions();
+      print('Headers: ${options.headers}');
+
+      final response = await _dio.patch(path, data: data, options: options);
+      return response;
+    } on DioException {
+      rethrow;
+    }
+  }
+
+  // 요청 옵션 가져오기
+  Future<Options> _getRequestOptions() async {
+    final accessToken = await TokenService.instance.getAccessToken();
+    return Options(
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        if (accessToken != null) 'Authorization': 'Bearer $accessToken',
+      },
+    );
   }
 }

--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:dio/dio.dart';
 import '../../data/models/user.dart';
 import '../services/storage_service.dart';
-import '../../data/repositories/auth_repository.dart';
+import '../services/token_service.dart';
 
 class AuthService with ChangeNotifier {
   static final AuthService _instance = AuthService._internal();
@@ -26,14 +26,26 @@ class AuthService with ChangeNotifier {
 
   Future<void> _init() async {
     await StorageService.instance.init();
+
+    // 토큰이 있는지 확인
+    final hasToken = await TokenService.instance.hasAccessToken();
+    if (!hasToken) {
+      // 토큰이 없으면 저장된 사용자 정보도 삭제
+      await StorageService.instance.remove('user');
+      _currentUser = null;
+      return;
+    }
+
     // 저장된 사용자 정보가 있는지 확인
     final savedUser = await StorageService.instance.getObject('user');
     if (savedUser != null) {
       try {
         _currentUser = User.fromJson(savedUser);
+        notifyListeners();
       } catch (e) {
         // 저장된 사용자 정보가 유효하지 않은 경우
         await StorageService.instance.remove('user');
+        _currentUser = null;
       }
     }
   }
@@ -47,19 +59,24 @@ class AuthService with ChangeNotifier {
       });
 
       if (response.statusCode == 200 && response.data != null) {
-        // 서버 응답에서 사용자 ID만 추출
         final userData = response.data;
 
-        // 사용자 정보 설정 (ID만 저장)
+        // JWT 토큰 저장
+        if (userData['accessToken'] != null &&
+            userData['refreshToken'] != null) {
+          await TokenService.instance.setTokens(
+            accessToken: userData['accessToken'],
+            refreshToken: userData['refreshToken'],
+          );
+        }
+
+        // 사용자 정보 설정
         _currentUser = User(
           id: userData['id'] ?? '',
           email: email,
+          nickname: userData['nickname'],
+          profileImageUrl: userData['profileImage'],
         );
-
-        // 토큰이 있다면 저장
-        if (userData['token'] != null) {
-          await StorageService.instance.setString('token', userData['token']);
-        }
 
         await StorageService.instance.setObject('user', _currentUser!.toJson());
         notifyListeners();
@@ -92,12 +109,44 @@ class AuthService with ChangeNotifier {
 
   Future<void> signOut() async {
     try {
+      // 토큰 삭제
+      await TokenService.instance.clearTokens();
+
+      // 사용자 정보 삭제
       _currentUser = null;
       await StorageService.instance.remove('user');
-      await StorageService.instance.remove('token');
       notifyListeners();
     } catch (e) {
       throw Exception('로그아웃 실패: ${e.toString()}');
+    }
+  }
+
+  // 사용자 정보 가져오기
+  Future<void> fetchUserProfile() async {
+    try {
+      final response = await _dio.get('/profile');
+
+      if (response.statusCode == 200 && response.data != null) {
+        final userData = response.data;
+
+        _currentUser = User(
+          id: userData['id'] ?? '',
+          email: userData['email'] ?? '',
+          nickname: userData['nickname'],
+          profileImageUrl: userData['profileImage'],
+          createdAt: userData['createdAt'] != null
+              ? DateTime.parse(userData['createdAt'])
+              : null,
+          updatedAt: userData['updatedAt'] != null
+              ? DateTime.parse(userData['updatedAt'])
+              : null,
+        );
+
+        await StorageService.instance.setObject('user', _currentUser!.toJson());
+        notifyListeners();
+      }
+    } catch (e) {
+      print('사용자 정보 가져오기 실패: ${e.toString()}');
     }
   }
 

--- a/lib/core/services/token_service.dart
+++ b/lib/core/services/token_service.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class TokenService {
+  static final TokenService _instance = TokenService._internal();
+  static TokenService get instance => _instance;
+
+  final FlutterSecureStorage _storage = const FlutterSecureStorage();
+
+  TokenService._internal();
+
+  // 액세스 토큰과 리프레시 토큰 저장
+  Future<void> setTokens({
+    required String accessToken,
+    required String refreshToken,
+  }) async {
+    await _storage.write(key: 'access_token', value: accessToken);
+    await _storage.write(key: 'refresh_token', value: refreshToken);
+  }
+
+  // 액세스 토큰 가져오기
+  Future<String?> getAccessToken() async {
+    return await _storage.read(key: 'access_token');
+  }
+
+  // 리프레시 토큰 가져오기
+  Future<String?> getRefreshToken() async {
+    return await _storage.read(key: 'refresh_token');
+  }
+
+  // 토큰 삭제 (로그아웃 시 사용)
+  Future<void> clearTokens() async {
+    await _storage.delete(key: 'access_token');
+    await _storage.delete(key: 'refresh_token');
+  }
+
+  // 액세스 토큰 존재 여부 확인
+  Future<bool> hasAccessToken() async {
+    final token = await getAccessToken();
+    return token != null && token.isNotEmpty;
+  }
+
+  // 리프레시 토큰 존재 여부 확인
+  Future<bool> hasRefreshToken() async {
+    final token = await getRefreshToken();
+    return token != null && token.isNotEmpty;
+  }
+}

--- a/lib/core/services/token_service.dart
+++ b/lib/core/services/token_service.dart
@@ -13,18 +13,29 @@ class TokenService {
     required String accessToken,
     required String refreshToken,
   }) async {
+    print('TokenService - 토큰 저장 시도');
+    print('저장할 액세스 토큰: $accessToken');
+    print('저장할 리프레시 토큰: $refreshToken');
+
     await _storage.write(key: 'access_token', value: accessToken);
     await _storage.write(key: 'refresh_token', value: refreshToken);
+    print('TokenService - 토큰 저장 완료');
   }
 
   // 액세스 토큰 가져오기
   Future<String?> getAccessToken() async {
-    return await _storage.read(key: 'access_token');
+    print('TokenService - 액세스 토큰 가져오기 시도');
+    final token = await _storage.read(key: 'access_token');
+    print('TokenService - 가져온 액세스 토큰: $token');
+    return token;
   }
 
   // 리프레시 토큰 가져오기
   Future<String?> getRefreshToken() async {
-    return await _storage.read(key: 'refresh_token');
+    print('TokenService - 리프레시 토큰 가져오기 시도');
+    final token = await _storage.read(key: 'refresh_token');
+    print('TokenService - 가져온 리프레시 토큰: $token');
+    return token;
   }
 
   // 토큰 삭제 (로그아웃 시 사용)

--- a/lib/core/services/user_service.dart
+++ b/lib/core/services/user_service.dart
@@ -1,0 +1,118 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import '../../data/models/user.dart';
+import '../services/storage_service.dart';
+import '../services/token_service.dart';
+
+class UserService with ChangeNotifier {
+  static final UserService _instance = UserService._internal();
+  static UserService get instance => _instance;
+
+  final Dio _dio = Dio(BaseOptions(
+    baseUrl: "http://10.0.2.2:8080/v1",
+    connectTimeout: const Duration(seconds: 5),
+    receiveTimeout: const Duration(seconds: 3),
+  ));
+  User? _currentUser;
+
+  User? get currentUser => _currentUser;
+
+  UserService._internal();
+
+  // 사용자 프로필 정보 가져오기
+  Future<void> fetchUserProfile() async {
+    try {
+      final response = await _dio.get('/users/me');
+
+      if (response.statusCode == 200 && response.data != null) {
+        final userData = response.data;
+        _currentUser = User.fromJson(userData);
+        await StorageService.instance.setObject('user', _currentUser!.toJson());
+        notifyListeners();
+      }
+    } catch (e) {
+      print('사용자 정보 가져오기 실패: ${e.toString()}');
+      // 에러 발생 시 저장된 사용자 정보 로드
+      _currentUser = await _getCurrentUser();
+      notifyListeners();
+    }
+  }
+
+  // 닉네임 변경
+  Future<void> changeNickname(String nickname) async {
+    try {
+      final accessToken =
+          await TokenService.instance.getAccessToken(); // 토큰 가져오기
+
+      final response = await _dio.patch(
+        '/users/me/nickname',
+        data: {'nickname': nickname},
+        options: Options(
+          headers: {'Authorization': 'Bearer $accessToken'},
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        // 현재 사용자 정보 업데이트
+        final currentUser = await _getCurrentUser();
+        if (currentUser != null) {
+          final updatedUser = currentUser.copyWith(nickname: nickname);
+          await StorageService.instance.setObject('user', updatedUser.toJson());
+        }
+      } else {
+        throw Exception('닉네임 변경 실패: 서버 응답 오류');
+      }
+    } catch (e) {
+      throw Exception('닉네임 변경 실패: ${e.toString()}');
+    }
+  }
+
+  // 비밀번호 변경
+  Future<void> changePassword({
+    required String currentPassword,
+    required String newPassword,
+    required String newPasswordConfirm,
+  }) async {
+    try {
+      final accessToken =
+          await TokenService.instance.getAccessToken(); // 토큰 가져오기
+
+      final response = await _dio.put(
+        '/users/me/password',
+        data: {
+          'currentPassword': currentPassword,
+          'newPassword': newPassword,
+          'newPasswordConfirm': newPasswordConfirm,
+        }, options: Options(
+          headers: {'Authorization': 'Bearer $accessToken'},
+        ),
+      );
+
+      if (response.statusCode != 200) {
+        throw Exception('비밀번호 변경 실패: 서버 응답 오류');
+      }
+    } catch (e) {
+      if (e is DioException && e.response != null) {
+        final responseData = e.response!.data;
+        if (responseData is Map<String, dynamic> &&
+            responseData.containsKey('message')) {
+          throw responseData['message'] as String;
+        }
+      }
+      throw '비밀번호 변경 실패: ${e.toString()}';
+    }
+  }
+
+  // 현재 사용자 정보 가져오기
+  Future<User?> _getCurrentUser() async {
+    final savedUser = await StorageService.instance.getObject('user');
+    if (savedUser != null) {
+      try {
+        return User.fromJson(savedUser);
+      } catch (e) {
+        return null;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/core/services/user_service.dart
+++ b/lib/core/services/user_service.dart
@@ -1,20 +1,14 @@
-import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:dio/dio.dart';
 import '../../data/models/user.dart';
 import '../services/storage_service.dart';
-import '../services/token_service.dart';
+import '../services/api_service.dart';
 
 class UserService with ChangeNotifier {
   static final UserService _instance = UserService._internal();
   static UserService get instance => _instance;
 
-  final Dio _dio = Dio(BaseOptions(
-    baseUrl: "http://10.0.2.2:8080/v1",
-    connectTimeout: const Duration(seconds: 5),
-    receiveTimeout: const Duration(seconds: 3),
-  ));
   User? _currentUser;
-
   User? get currentUser => _currentUser;
 
   UserService._internal();
@@ -22,7 +16,7 @@ class UserService with ChangeNotifier {
   // 사용자 프로필 정보 가져오기
   Future<void> fetchUserProfile() async {
     try {
-      final response = await _dio.get('/users/me');
+      final response = await ApiService.instance.get('/users/me');
 
       if (response.statusCode == 200 && response.data != null) {
         final userData = response.data;
@@ -32,7 +26,6 @@ class UserService with ChangeNotifier {
       }
     } catch (e) {
       print('사용자 정보 가져오기 실패: ${e.toString()}');
-      // 에러 발생 시 저장된 사용자 정보 로드
       _currentUser = await _getCurrentUser();
       notifyListeners();
     }
@@ -41,29 +34,46 @@ class UserService with ChangeNotifier {
   // 닉네임 변경
   Future<void> changeNickname(String nickname) async {
     try {
-      final accessToken =
-          await TokenService.instance.getAccessToken(); // 토큰 가져오기
+      print('닉네임 변경 요청 - URL: /users/me/nickname');
+      print('요청 데이터: ${{'nickname': nickname}}');
 
-      final response = await _dio.patch(
+      final response = await ApiService.instance.patch(
         '/users/me/nickname',
         data: {'nickname': nickname},
-        options: Options(
-          headers: {'Authorization': 'Bearer $accessToken'},
-        ),
       );
 
+      print('응답 상태 코드: ${response.statusCode}');
+      print('응답 데이터: ${response.data}');
+      print('응답 헤더: ${response.headers}');
+
       if (response.statusCode == 200) {
-        // 현재 사용자 정보 업데이트
         final currentUser = await _getCurrentUser();
         if (currentUser != null) {
           final updatedUser = currentUser.copyWith(nickname: nickname);
           await StorageService.instance.setObject('user', updatedUser.toJson());
+          _currentUser = updatedUser;
+          notifyListeners();
         }
       } else {
         throw Exception('닉네임 변경 실패: 서버 응답 오류');
       }
     } catch (e) {
-      throw Exception('닉네임 변경 실패: ${e.toString()}');
+      print('에러 상세 정보:');
+      if (e is DioException) {
+        print('요청 데이터: ${e.requestOptions.data}');
+        print('요청 헤더: ${e.requestOptions.headers}');
+        print('응답 상태 코드: ${e.response?.statusCode}');
+        print('응답 데이터: ${e.response?.data}');
+
+        if (e.response != null) {
+          final responseData = e.response!.data;
+          if (responseData is Map<String, dynamic> &&
+              responseData.containsKey('message')) {
+            throw responseData['message'] as String;
+          }
+        }
+      }
+      throw '닉네임 변경 실패: ${e.toString()}';
     }
   }
 
@@ -74,18 +84,13 @@ class UserService with ChangeNotifier {
     required String newPasswordConfirm,
   }) async {
     try {
-      final accessToken =
-          await TokenService.instance.getAccessToken(); // 토큰 가져오기
-
-      final response = await _dio.put(
+      final response = await ApiService.instance.put(
         '/users/me/password',
         data: {
           'currentPassword': currentPassword,
           'newPassword': newPassword,
           'newPasswordConfirm': newPasswordConfirm,
-        }, options: Options(
-          headers: {'Authorization': 'Bearer $accessToken'},
-        ),
+        },
       );
 
       if (response.statusCode != 200) {

--- a/lib/core/widgets/bottom_navigation_bar.dart
+++ b/lib/core/widgets/bottom_navigation_bar.dart
@@ -15,7 +15,7 @@ class AppBottomNavigationBar extends StatelessWidget {
   Widget build(BuildContext context) {
     return BottomNavigationBar(
       currentIndex: currentIndex,
-      onTap: (index) {
+      onTap: (index) async {
         if (index == currentIndex) return;
 
         switch (index) {
@@ -36,9 +36,11 @@ class AppBottomNavigationBar extends StatelessWidget {
             );
             break;
           case 3:
-            // 테스트용 계정으로 마이페이지 접근
-            AuthService.instance.setTestUser('bannabee@naver.com');
-            Navigator.of(context).pushReplacementNamed(Routes.mypage);
+            if (AuthService.instance.isAuthenticated) {
+              Navigator.of(context).pushReplacementNamed(Routes.mypage);
+            } else {
+              Navigator.of(context).pushReplacementNamed(Routes.login);
+            }
             break;
         }
       },

--- a/lib/data/models/rental.dart
+++ b/lib/data/models/rental.dart
@@ -7,7 +7,7 @@ enum RentalStatus {
 
 class Rental {
   final String id;
-  final String userId;
+  final String? userId;
   final String accessoryId;
   final String stationId;
   final String accessoryName;
@@ -21,7 +21,7 @@ class Rental {
 
   Rental({
     required this.id,
-    required this.userId,
+    this.userId,
     required this.accessoryId,
     required this.stationId,
     required this.accessoryName,
@@ -37,7 +37,7 @@ class Rental {
   factory Rental.fromJson(Map<String, dynamic> json) {
     return Rental(
       id: json['id'] as String,
-      userId: json['userId'] as String,
+      userId: json['userId'] as String?,
       accessoryId: json['accessoryId'] as String,
       stationId: json['stationId'] as String,
       accessoryName: json['accessoryName'] as String,

--- a/lib/data/models/user.dart
+++ b/lib/data/models/user.dart
@@ -1,7 +1,7 @@
 import 'rental.dart';
 
 class User {
-  final String id;
+  final String? id;
   final String email;
   final String? nickname;
   final String? profileImageUrl;
@@ -10,7 +10,7 @@ class User {
   final List<Rental> rentals;
 
   User({
-    required this.id,
+    this.id,
     required this.email,
     this.nickname,
     this.profileImageUrl,
@@ -21,16 +21,14 @@ class User {
 
   factory User.fromJson(Map<String, dynamic> json) {
     return User(
-      id: json['id'] as String,
-      email: json['email'] as String,
-      nickname: json['nickname'] as String?,
-      profileImageUrl: json['profileImageUrl'] as String?,
-      createdAt: json['createdAt'] != null
-          ? DateTime.parse(json['createdAt'] as String)
-          : null,
-      updatedAt: json['updatedAt'] != null
-          ? DateTime.parse(json['updatedAt'] as String)
-          : null,
+      id: json['id'],
+      email: json['email'],
+      nickname: json['nickname'],
+      profileImageUrl: json['profileImage'],
+      createdAt:
+          json['createdAt'] != null ? DateTime.parse(json['createdAt']) : null,
+      updatedAt:
+          json['updatedAt'] != null ? DateTime.parse(json['updatedAt']) : null,
       rentals: json['rentals'] != null
           ? (json['rentals'] as List)
               .map((rental) => Rental.fromJson(rental))
@@ -40,19 +38,14 @@ class User {
   }
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = {
+    return {
       'id': id,
       'email': email,
+      'nickname': nickname,
+      'profileImage': profileImageUrl,
+      'createdAt': createdAt?.toIso8601String(),
+      'updatedAt': updatedAt?.toIso8601String(),
     };
-
-    if (nickname != null) data['nickname'] = nickname;
-    if (profileImageUrl != null) data['profileImageUrl'] = profileImageUrl;
-    if (createdAt != null) data['createdAt'] = createdAt!.toIso8601String();
-    if (updatedAt != null) data['updatedAt'] = updatedAt!.toIso8601String();
-    if (rentals.isNotEmpty)
-      data['rentals'] = rentals.map((rental) => rental.toJson()).toList();
-
-    return data;
   }
 
   User copyWith({

--- a/lib/features/auth/views/login_view.dart
+++ b/lib/features/auth/views/login_view.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import '../../../core/constants/app_colors.dart';
 import '../../../core/constants/app_theme.dart';
 import '../../../core/widgets/loading_animation.dart';
-import '../../../core/widgets/bottom_navigation_bar.dart';
 import '../../../core/services/auth_service.dart';
 import '../../../app/routes.dart';
 
@@ -47,7 +46,7 @@ class _LoginViewState extends State<LoginView> {
       await AuthService.instance.signInWithEmail(email, password);
 
       if (mounted) {
-        Navigator.of(context).pushReplacementNamed(Routes.home);
+        Navigator.of(context).pushReplacementNamed(Routes.mypage);
       }
     } catch (e) {
       setState(() {
@@ -70,119 +69,98 @@ class _LoginViewState extends State<LoginView> {
         centerTitle: true,
       ),
       body: SafeArea(
-        child: Stack(
-          children: [
-            DefaultTextStyle.merge(
-              style: const TextStyle(
-                fontSize: 15,
-                color: Colors.black87,
-                height: 1.5,
-              ),
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
+        child: DefaultTextStyle.merge(
+          style: const TextStyle(
+            fontSize: 15,
+            color: Colors.black87,
+            height: 1.5,
+          ),
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const SizedBox(height: 32),
+                const Text(
+                  'Bannabee',
+                  style: AppTheme.headlineLarge,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 48),
+                TextField(
+                  controller: _emailController,
+                  keyboardType: TextInputType.emailAddress,
+                  decoration: InputDecoration(
+                    hintText: '이메일',
+                    contentPadding: const EdgeInsets.all(16),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(8),
+                      borderSide: const BorderSide(color: AppColors.lightGrey),
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(8),
+                      borderSide: const BorderSide(color: AppColors.lightGrey),
+                    ),
+                  ),
+                  autocorrect: false,
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: _passwordController,
+                  obscureText: true,
+                  decoration: InputDecoration(
+                    hintText: '비밀번호',
+                    contentPadding: const EdgeInsets.all(16),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(8),
+                      borderSide: const BorderSide(color: AppColors.lightGrey),
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(8),
+                      borderSide: const BorderSide(color: AppColors.lightGrey),
+                    ),
+                  ),
+                  autocorrect: false,
+                ),
+                if (_error != null) ...[
+                  const SizedBox(height: 16),
+                  Text(
+                    _error!,
+                    style: AppTheme.bodyMedium.copyWith(
+                      color: AppColors.error,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+                const SizedBox(height: 24),
+                if (_isLoading)
+                  const HoneyLoadingAnimation(isStationSelected: false)
+                else
+                  ElevatedButton(
+                    onPressed: _login,
+                    child: const Text('로그인'),
+                  ),
+                const SizedBox(height: 16),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
                   children: [
-                    const SizedBox(height: 32),
-                    const Text(
-                      'Bannabee',
-                      style: AppTheme.headlineLarge,
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 48),
-                    TextField(
-                      controller: _emailController,
-                      keyboardType: TextInputType.emailAddress,
-                      decoration: InputDecoration(
-                        hintText: '이메일',
-                        contentPadding: const EdgeInsets.all(16),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(8),
-                          borderSide:
-                              const BorderSide(color: AppColors.lightGrey),
-                        ),
-                        enabledBorder: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(8),
-                          borderSide:
-                              const BorderSide(color: AppColors.lightGrey),
-                        ),
+                    Text(
+                      '아직 계정이 없으신가요?',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Colors.grey[600],
                       ),
-                      autocorrect: false,
                     ),
-                    const SizedBox(height: 16),
-                    TextField(
-                      controller: _passwordController,
-                      obscureText: true,
-                      decoration: InputDecoration(
-                        hintText: '비밀번호',
-                        contentPadding: const EdgeInsets.all(16),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(8),
-                          borderSide:
-                              const BorderSide(color: AppColors.lightGrey),
-                        ),
-                        enabledBorder: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(8),
-                          borderSide:
-                              const BorderSide(color: AppColors.lightGrey),
-                        ),
-                      ),
-                      autocorrect: false,
-                    ),
-                    if (_error != null) ...[
-                      const SizedBox(height: 16),
-                      Text(
-                        _error!,
-                        style: AppTheme.bodyMedium.copyWith(
-                          color: AppColors.error,
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
-                    ],
-                    const SizedBox(height: 24),
-                    if (_isLoading)
-                      const HoneyLoadingAnimation(isStationSelected: false)
-                    else
-                      ElevatedButton(
-                        onPressed: _login,
-                        child: const Text('로그인'),
-                      ),
-                    const SizedBox(height: 16),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(
-                          '아직 계정이 없으신가요?',
-                          style: TextStyle(
-                            fontSize: 12,
-                            color: Colors.grey[600],
-                          ),
-                        ),
-                        TextButton(
-                          onPressed: () {
-                            Navigator.of(context).pushNamed(Routes.terms);
-                          },
-                          style: TextButton.styleFrom(
-                            padding: const EdgeInsets.symmetric(horizontal: 8),
-                          ),
-                          child: const Text(
-                            '회원가입',
-                            style: TextStyle(
-                              fontSize: 12,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 8),
                     TextButton(
                       onPressed: () {
-                        Navigator.of(context).pushNamed(Routes.forgotPassword);
+                        Navigator.of(context).pushNamed(Routes.terms);
                       },
+                      style: TextButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
+                      ),
                       child: const Text(
-                        '비밀번호 찾기',
+                        '회원가입',
                         style: TextStyle(
                           fontSize: 12,
                           fontWeight: FontWeight.bold,
@@ -191,13 +169,22 @@ class _LoginViewState extends State<LoginView> {
                     ),
                   ],
                 ),
-              ),
+                const SizedBox(height: 8),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pushNamed(Routes.forgotPassword);
+                  },
+                  child: const Text(
+                    '비밀번호 찾기',
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ],
             ),
-            const Align(
-              alignment: Alignment.bottomCenter,
-              child: AppBottomNavigationBar(currentIndex: 3),
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/features/home/views/home_view.dart
+++ b/lib/features/home/views/home_view.dart
@@ -5,8 +5,6 @@ import '../../../core/widgets/bottom_navigation_bar.dart';
 import '../../../core/widgets/loading_animation.dart';
 import '../../../app/routes.dart';
 import '../../../core/widgets/map_view.dart';
-import '../../../core/services/storage_service.dart';
-import '../../../data/models/rental.dart';
 import 'dart:async';
 
 class HomeView extends StatefulWidget {

--- a/lib/features/mypage/viewmodels/mypage_viewmodel.dart
+++ b/lib/features/mypage/viewmodels/mypage_viewmodel.dart
@@ -38,10 +38,15 @@ class MyPageViewModel extends ChangeNotifier {
         return;
       }
 
-      final userId = _authService.currentUser!.id;
-      final user = await _userRepository.get(userId);
-      _user = user;
-      _error = null;
+      final currentUser = _authService.currentUser;
+      if (currentUser?.id == null) {
+        _error = '사용자 ID를 찾을 수 없습니다.';
+        _user = null;
+      } else {
+        final user = await _userRepository.get(currentUser!.id!);
+        _user = user;
+        _error = null;
+      }
     } catch (e) {
       _error = '사용자 정보를 불러오는데 실패했습니다.';
       _user = null;

--- a/lib/features/mypage/views/change_nickname_view.dart
+++ b/lib/features/mypage/views/change_nickname_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../../../core/constants/app_colors.dart';
 import '../../../core/constants/app_theme.dart';
 import '../../../core/services/auth_service.dart';
+import '../../../core/services/user_service.dart';
 
 class ChangeNicknameView extends StatefulWidget {
   const ChangeNicknameView({super.key});
@@ -31,7 +32,7 @@ class _ChangeNicknameViewState extends State<ChangeNicknameView> {
     super.dispose();
   }
 
-  void _changeNickname() {
+  void _changeNickname() async {
     final nickname = _nicknameController.text.trim();
 
     if (nickname.isEmpty) {
@@ -41,20 +42,34 @@ class _ChangeNicknameViewState extends State<ChangeNicknameView> {
       return;
     }
 
+    if (nickname.length > 8) {
+      setState(() {
+        _error = '닉네임은 8자 이하여야 합니다.';
+      });
+      return;
+    }
+
     setState(() {
       _isLoading = true;
       _error = null;
     });
 
-    // TODO: 닉네임 변경 API 연동
-    Future.delayed(const Duration(seconds: 1), () {
+    try {
+      await UserService.instance.changeNickname(nickname);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('닉네임이 변경되었습니다.')),
         );
         Navigator.of(context).pop();
       }
-    });
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = e.toString();
+          _isLoading = false;
+        });
+      }
+    }
   }
 
   @override

--- a/lib/features/mypage/views/change_password_view.dart
+++ b/lib/features/mypage/views/change_password_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../../core/constants/app_colors.dart';
 import '../../../core/constants/app_theme.dart';
+import '../../../core/services/user_service.dart';
 
 class ChangePasswordView extends StatefulWidget {
   const ChangePasswordView({super.key});
@@ -27,7 +28,7 @@ class _ChangePasswordViewState extends State<ChangePasswordView> {
     super.dispose();
   }
 
-  void _changePassword() {
+  void _changePassword() async {
     final currentPassword = _currentPasswordController.text.trim();
     final newPassword = _newPasswordController.text.trim();
     final confirmPassword = _confirmPasswordController.text.trim();
@@ -52,20 +53,40 @@ class _ChangePasswordViewState extends State<ChangePasswordView> {
       return;
     }
 
+    // 새 비밀번호와 확인 비밀번호 일치 여부 확인
+    if (newPassword != confirmPassword) {
+      setState(() {
+        _error = '새 비밀번호와 확인 비밀번호가 일치하지 않습니다.';
+      });
+      return;
+    }
+
     setState(() {
       _isLoading = true;
       _error = null;
     });
 
-    // TODO: 비밀번호 변경 API 연동
-    Future.delayed(const Duration(seconds: 1), () {
+    try {
+      await UserService.instance.changePassword(
+        currentPassword: currentPassword,
+        newPassword: newPassword,
+        newPasswordConfirm: confirmPassword,
+      );
+
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('비밀번호가 변경되었습니다.')),
         );
         Navigator.of(context).pop();
       }
-    });
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = e.toString();
+          _isLoading = false;
+        });
+      }
+    }
   }
 
   @override

--- a/lib/features/mypage/views/edit_profile_view.dart
+++ b/lib/features/mypage/views/edit_profile_view.dart
@@ -199,14 +199,6 @@ class _EditProfileViewState extends State<EditProfileView> {
                             fit: BoxFit.cover,
                           ),
                         ),
-                        child: (_selectedImage == null &&
-                                user?.profileImageUrl == null)
-                            ? const Icon(
-                                Icons.person,
-                                size: 40,
-                                color: Colors.grey,
-                              )
-                            : null,
                       ),
                     ],
                   ),

--- a/lib/features/mypage/views/mypage_view.dart
+++ b/lib/features/mypage/views/mypage_view.dart
@@ -7,9 +7,24 @@ import '../../../core/widgets/bottom_navigation_bar.dart';
 import '../../../app/routes.dart';
 import '../../../features/rental/views/active_rentals_view.dart';
 import '../../../features/rental/views/rental_history_view.dart';
+import 'package:provider/provider.dart';
 
-class MyPageView extends StatelessWidget {
+class MyPageView extends StatefulWidget {
   const MyPageView({super.key});
+
+  @override
+  State<MyPageView> createState() => _MyPageViewState();
+}
+
+class _MyPageViewState extends State<MyPageView> {
+  @override
+  void initState() {
+    super.initState();
+    // 페이지가 로드될 때 사용자 프로필 정보를 가져옵니다
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      AuthService.instance.fetchUserProfile();
+    });
+  }
 
   // URL 실행 함수
   Future<void> _launchURL(String url) async {
@@ -21,275 +36,293 @@ class MyPageView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final user = AuthService.instance.currentUser;
+    // AuthService를 리스닝하여 사용자 정보 변경 시 UI 업데이트
+    return ChangeNotifierProvider.value(
+      value: AuthService.instance,
+      child: Consumer<AuthService>(
+        builder: (context, authService, _) {
+          final user = authService.currentUser;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('마이페이지'),
-        centerTitle: true,
-        automaticallyImplyLeading: false,
-      ),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(16.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              // 1. 회원 정보 필드
-              Container(
-                padding: const EdgeInsets.all(20),
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    colors: [
-                      AppColors.primary.withOpacity(0.8),
-                      AppColors.primary.withOpacity(0.6),
-                    ],
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                  ),
-                  borderRadius: BorderRadius.circular(16),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withOpacity(0.1),
-                      blurRadius: 10,
-                      offset: const Offset(0, 4),
-                    ),
-                  ],
-                ),
-                child: Row(
+          return Scaffold(
+            appBar: AppBar(
+              title: const Text('마이페이지'),
+              centerTitle: true,
+              automaticallyImplyLeading: false,
+            ),
+            body: SafeArea(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
+                    // 1. 회원 정보 필드
                     Container(
-                      width: 70,
-                      height: 70,
+                      padding: const EdgeInsets.all(20),
                       decoration: BoxDecoration(
-                        shape: BoxShape.circle,
-                        border: Border.all(color: Colors.white, width: 2),
-                        image: const DecorationImage(
-                          image: AssetImage('assets/images/profile.jpg'),
-                          fit: BoxFit.cover,
+                        gradient: LinearGradient(
+                          colors: [
+                            AppColors.primary.withOpacity(0.8),
+                            AppColors.primary.withOpacity(0.6),
+                          ],
+                          begin: Alignment.topLeft,
+                          end: Alignment.bottomRight,
                         ),
+                        borderRadius: BorderRadius.circular(16),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withOpacity(0.1),
+                            blurRadius: 10,
+                            offset: const Offset(0, 4),
+                          ),
+                        ],
                       ),
-                    ),
-                    const SizedBox(width: 20),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
+                      child: Row(
                         children: [
-                          Text(
-                            '${user?.nickname}님',
-                            style: AppTheme.titleMedium.copyWith(
-                              color: Colors.white,
-                              fontSize: 22,
+                          Container(
+                            width: 70,
+                            height: 70,
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              border: Border.all(color: Colors.white, width: 2),
+                              image: DecorationImage(
+                                image: user?.profileImageUrl != null &&
+                                        user!.profileImageUrl!.isNotEmpty
+                                    ? (user.profileImageUrl!.startsWith('http')
+                                        ? NetworkImage(user.profileImageUrl!)
+                                            as ImageProvider
+                                        : AssetImage(user.profileImageUrl!))
+                                    : const AssetImage(
+                                        'assets/images/profile.jpg'),
+                                fit: BoxFit.cover,
+                              ),
                             ),
                           ),
-                          const SizedBox(height: 4),
-                          Text(
-                            user?.email ?? '',
-                            style: AppTheme.bodyMedium.copyWith(
-                              color: Colors.white.withOpacity(0.9),
+                          const SizedBox(width: 20),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  user?.nickname != null &&
+                                          user!.nickname!.isNotEmpty
+                                      ? '${user.nickname}님'
+                                      : '사용자님',
+                                  style: AppTheme.titleMedium.copyWith(
+                                    color: Colors.white,
+                                    fontSize: 22,
+                                  ),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  user?.email ?? '',
+                                  style: AppTheme.bodyMedium.copyWith(
+                                    color: Colors.white.withOpacity(0.9),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                          IconButton(
+                            onPressed: () {
+                              Navigator.of(context)
+                                  .pushNamed(Routes.editProfile);
+                            },
+                            icon: const Icon(
+                              Icons.settings,
+                              color: Colors.white,
                             ),
                           ),
                         ],
                       ),
                     ),
-                    IconButton(
-                      onPressed: () {
-                        Navigator.of(context).pushNamed(Routes.editProfile);
-                      },
-                      icon: const Icon(
-                        Icons.settings,
+                    const SizedBox(height: 24),
+
+                    // 2. 대여 관련 메뉴
+                    Container(
+                      padding: const EdgeInsets.all(20),
+                      decoration: BoxDecoration(
                         color: Colors.white,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 24),
-
-              // 2. 대여 관련 메뉴
-              Container(
-                padding: const EdgeInsets.all(20),
-                decoration: BoxDecoration(
-                  color: Colors.white,
-                  borderRadius: BorderRadius.circular(16),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withOpacity(0.05),
-                      blurRadius: 10,
-                      offset: const Offset(0, 4),
-                    ),
-                  ],
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      '대여 관리',
-                      style: AppTheme.titleMedium.copyWith(
-                        fontSize: 18,
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: _buildMenuButton(
-                            context,
-                            icon: Icons.access_time_filled,
-                            label: '대여 현황',
-                            onTap: () {
-                              Navigator.of(context).push(
-                                MaterialPageRoute(
-                                  builder: (context) =>
-                                      const ActiveRentalsView(),
-                                ),
-                              );
-                            },
+                        borderRadius: BorderRadius.circular(16),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withOpacity(0.05),
+                            blurRadius: 10,
+                            offset: const Offset(0, 4),
                           ),
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: _buildMenuButton(
-                            context,
-                            icon: Icons.receipt_long,
-                            label: '대여 내역',
-                            onTap: () {
-                              Navigator.of(context).push(
-                                MaterialPageRoute(
-                                  builder: (context) =>
-                                      const RentalHistoryView(),
-                                ),
-                              );
-                            },
+                        ],
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '대여 관리',
+                            style: AppTheme.titleMedium.copyWith(
+                              fontSize: 18,
+                            ),
                           ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 24),
-
-              // 3. 고객지원 필드
-              Container(
-                padding: const EdgeInsets.all(20),
-                decoration: BoxDecoration(
-                  color: Colors.white,
-                  borderRadius: BorderRadius.circular(16),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withOpacity(0.05),
-                      blurRadius: 10,
-                      offset: const Offset(0, 4),
-                    ),
-                  ],
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      '고객지원',
-                      style: AppTheme.titleMedium.copyWith(
-                        fontSize: 18,
+                          const SizedBox(height: 16),
+                          Row(
+                            children: [
+                              Expanded(
+                                child: _buildMenuButton(
+                                  context,
+                                  icon: Icons.access_time_filled,
+                                  label: '대여 현황',
+                                  onTap: () {
+                                    Navigator.of(context).push(
+                                      MaterialPageRoute(
+                                        builder: (context) =>
+                                            const ActiveRentalsView(),
+                                      ),
+                                    );
+                                  },
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: _buildMenuButton(
+                                  context,
+                                  icon: Icons.receipt_long,
+                                  label: '대여 내역',
+                                  onTap: () {
+                                    Navigator.of(context).push(
+                                      MaterialPageRoute(
+                                        builder: (context) =>
+                                            const RentalHistoryView(),
+                                      ),
+                                    );
+                                  },
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
                       ),
                     ),
-                    const SizedBox(height: 16),
-                    GridView.count(
-                      shrinkWrap: true,
-                      physics: const NeverScrollableScrollPhysics(),
-                      crossAxisCount: 3,
-                      mainAxisSpacing: 16,
-                      crossAxisSpacing: 16,
-                      childAspectRatio: 1.1,
-                      children: [
-                        _buildSupportButton(
-                          '이용 약관',
-                          Icons.description_outlined,
-                          onPressed: () {
-                            // TODO: 이용 약관 페이지로 이동
-                          },
+                    const SizedBox(height: 24),
+
+                    // 3. 고객지원 필드
+                    Container(
+                      padding: const EdgeInsets.all(20),
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.circular(16),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withOpacity(0.05),
+                            blurRadius: 10,
+                            offset: const Offset(0, 4),
+                          ),
+                        ],
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '고객지원',
+                            style: AppTheme.titleMedium.copyWith(
+                              fontSize: 18,
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                          GridView.count(
+                            shrinkWrap: true,
+                            physics: const NeverScrollableScrollPhysics(),
+                            crossAxisCount: 3,
+                            mainAxisSpacing: 16,
+                            crossAxisSpacing: 16,
+                            childAspectRatio: 1.1,
+                            children: [
+                              _buildSupportButton(
+                                '이용 약관',
+                                Icons.description_outlined,
+                                onPressed: () {
+                                  // TODO: 이용 약관 페이지로 이동
+                                },
+                              ),
+                              _buildSupportButton(
+                                '개인정보\n처리방침',
+                                Icons.security_outlined,
+                                onPressed: () {
+                                  // TODO: 개인정보 처리방침 페이지로 이동
+                                },
+                              ),
+                              _buildSupportButton(
+                                '공지사항',
+                                Icons.notifications_outlined,
+                                onPressed: () {
+                                  Navigator.of(context)
+                                      .pushNamed(Routes.noticeList);
+                                },
+                              ),
+                              _buildSupportButton(
+                                '자주 묻는 질문',
+                                Icons.help_outline,
+                                onPressed: () {
+                                  // TODO: FAQ 페이지로 이동
+                                },
+                              ),
+                              _buildSupportButton(
+                                '전화문의',
+                                Icons.phone_outlined,
+                                onPressed: () {
+                                  // TODO: 전화문의 기능 구현
+                                },
+                              ),
+                              _buildSupportButton(
+                                '1:1 채팅상담',
+                                Icons.chat_outlined,
+                                onPressed: () {
+                                  _launchURL('http://pf.kakao.com/_uRFKn');
+                                },
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+
+                    // 4. 로그아웃 버튼
+                    ElevatedButton.icon(
+                      onPressed: () async {
+                        try {
+                          await AuthService.instance.signOut();
+                          if (context.mounted) {
+                            Navigator.of(context).pushNamedAndRemoveUntil(
+                              Routes.login,
+                              (route) => false,
+                            );
+                          }
+                        } catch (e) {
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                  content: Text('로그아웃 실패: ${e.toString()}')),
+                            );
+                          }
+                        }
+                      },
+                      icon: const Icon(Icons.logout, color: Colors.grey),
+                      label: const Text('로그아웃'),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.white,
+                        foregroundColor: Colors.grey,
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          side: BorderSide(color: Colors.grey.withOpacity(0.5)),
                         ),
-                        _buildSupportButton(
-                          '개인정보\n처리방침',
-                          Icons.security_outlined,
-                          onPressed: () {
-                            // TODO: 개인정보 처리방침 페이지로 이동
-                          },
-                        ),
-                        _buildSupportButton(
-                          '공지사항',
-                          Icons.notifications_outlined,
-                          onPressed: () {
-                            Navigator.of(context).pushNamed(Routes.noticeList);
-                          },
-                        ),
-                        _buildSupportButton(
-                          '자주 묻는 질문',
-                          Icons.help_outline,
-                          onPressed: () {
-                            // TODO: FAQ 페이지로 이동
-                          },
-                        ),
-                        _buildSupportButton(
-                          '전화문의',
-                          Icons.phone_outlined,
-                          onPressed: () {
-                            // TODO: 전화문의 기능 구현
-                          },
-                        ),
-                        _buildSupportButton(
-                          '1:1 채팅상담',
-                          Icons.chat_outlined,
-                          onPressed: () {
-                            _launchURL('http://pf.kakao.com/_uRFKn');
-                          },
-                        ),
-                      ],
+                      ),
                     ),
                   ],
                 ),
               ),
-              const SizedBox(height: 24),
-
-              // 4. 로그아웃 버튼
-              ElevatedButton.icon(
-                onPressed: null,
-                icon: const Icon(Icons.logout, color: Colors.grey),
-                label: const Text('로그아웃'),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.white,
-                  foregroundColor: Colors.grey,
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    side: BorderSide(color: Colors.grey.withOpacity(0.5)),
-                  ),
-                ),
-              ),
-
-              // 디버깅용 로그인 페이지 이동 버튼
-              const SizedBox(height: 16),
-              ElevatedButton.icon(
-                onPressed: () {
-                  Navigator.of(context).pushNamed(Routes.login);
-                },
-                icon: const Icon(Icons.login, color: AppColors.primary),
-                label: const Text('로그인 페이지로 이동'),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.white,
-                  foregroundColor: AppColors.primary,
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    side: BorderSide(color: AppColors.primary.withOpacity(0.5)),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
+            ),
+            bottomNavigationBar: const AppBottomNavigationBar(currentIndex: 3),
+          );
+        },
       ),
-      bottomNavigationBar: const AppBottomNavigationBar(currentIndex: 3),
     );
   }
 

--- a/lib/features/mypage/views/mypage_view.dart
+++ b/lib/features/mypage/views/mypage_view.dart
@@ -80,22 +80,37 @@ class _MyPageViewState extends State<MyPageView> {
                       child: Row(
                         children: [
                           Container(
-                            width: 70,
-                            height: 70,
+                            width: 80,
+                            height: 80,
                             decoration: BoxDecoration(
                               shape: BoxShape.circle,
-                              border: Border.all(color: Colors.white, width: 2),
-                              image: DecorationImage(
-                                image: user?.profileImageUrl != null &&
-                                        user!.profileImageUrl!.isNotEmpty
-                                    ? (user.profileImageUrl!.startsWith('http')
-                                        ? NetworkImage(user.profileImageUrl!)
-                                            as ImageProvider
-                                        : AssetImage(user.profileImageUrl!))
-                                    : const AssetImage(
-                                        'assets/images/profile.jpg'),
-                                fit: BoxFit.cover,
+                              border: Border.all(
+                                color: Colors.white,
+                                width: 2,
                               ),
+                            ),
+                            child: ClipOval(
+                              child: user?.profileImageUrl != null &&
+                                      user!.profileImageUrl!.isNotEmpty
+                                  ? Image(
+                                      image: user.profileImageUrl!
+                                              .startsWith('http')
+                                          ? NetworkImage(user.profileImageUrl!)
+                                          : AssetImage(user.profileImageUrl!)
+                                              as ImageProvider,
+                                      fit: BoxFit.cover,
+                                      errorBuilder:
+                                          (context, error, stackTrace) {
+                                        return Image.asset(
+                                          'assets/images/profile.jpg',
+                                          fit: BoxFit.cover,
+                                        );
+                                      },
+                                    )
+                                  : Image.asset(
+                                      'assets/images/profile.jpg',
+                                      fit: BoxFit.cover,
+                                    ),
                             ),
                           ),
                           const SizedBox(width: 20),

--- a/lib/features/mypage/views/mypage_view.dart
+++ b/lib/features/mypage/views/mypage_view.dart
@@ -3,6 +3,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../../../core/constants/app_colors.dart';
 import '../../../core/constants/app_theme.dart';
 import '../../../core/services/auth_service.dart';
+import '../../../core/services/user_service.dart';
 import '../../../core/widgets/bottom_navigation_bar.dart';
 import '../../../app/routes.dart';
 import '../../../features/rental/views/active_rentals_view.dart';
@@ -22,7 +23,7 @@ class _MyPageViewState extends State<MyPageView> {
     super.initState();
     // 페이지가 로드될 때 사용자 프로필 정보를 가져옵니다
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      AuthService.instance.fetchUserProfile();
+      UserService.instance.fetchUserProfile();
     });
   }
 
@@ -36,12 +37,12 @@ class _MyPageViewState extends State<MyPageView> {
 
   @override
   Widget build(BuildContext context) {
-    // AuthService를 리스닝하여 사용자 정보 변경 시 UI 업데이트
+    // UserService를 리스닝하여 사용자 정보 변경 시 UI 업데이트
     return ChangeNotifierProvider.value(
-      value: AuthService.instance,
-      child: Consumer<AuthService>(
-        builder: (context, authService, _) {
-          final user = authService.currentUser;
+      value: UserService.instance,
+      child: Consumer<UserService>(
+        builder: (context, userService, _) {
+          final user = userService.currentUser;
 
           return Scaffold(
             appBar: AppBar(

--- a/lib/features/rental/viewmodels/rental_status_viewmodel.dart
+++ b/lib/features/rental/viewmodels/rental_status_viewmodel.dart
@@ -21,7 +21,7 @@ class RentalStatusViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final user = await AuthService.instance.currentUser;
+      final user = AuthService.instance.currentUser;
       if (user == null) {
         _error = '로그인이 필요합니다';
         return;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'firebase_options.dart';
 import 'app/routes.dart';
 import 'core/constants/app_colors.dart';
 import 'core/services/auth_service.dart';
+import 'core/services/api_service.dart';
 import 'data/models/rental.dart';
 import 'data/models/accessory.dart';
 import 'features/auth/views/login_view.dart';
@@ -48,6 +49,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Bannabee',
       debugShowCheckedModeBanner: false,
+      navigatorKey: ApiService.navigatorKey,
       theme: ThemeData(
         primaryColor: AppColors.primary,
         colorScheme: ColorScheme.fromSeed(

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,16 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_linux/file_selector_plugin.h>
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
+  flutter_secure_storage_linux
   url_launcher_linux
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import file_selector_macos
 import firebase_auth
 import firebase_core
+import flutter_secure_storage_macos
 import geolocator_apple
 import mobile_scanner
 import path_provider_foundation
@@ -18,6 +19,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -230,6 +230,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.27"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.4"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: bf7404619d7ab5c0a1151d7c4e802edad8f33535abfbeff2f9e1fe1274e2d705
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -805,6 +853,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: daf97c9d80197ed7b619040e86c8ab9a9dad285e7671ee7390f9180cc828a51e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.10.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   dio: ^5.4.0
   # 로컬 저장소
   shared_preferences: ^2.2.2
+  flutter_secure_storage: ^9.0.0
   # 위치 서비스
   geolocator: ^10.1.0
   flutter_naver_map: ^1.1.1

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <file_selector_windows/file_selector_windows.h>
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
+#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <geolocator_windows/geolocator_windows.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
@@ -20,6 +21,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseAuthPluginCApi"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
+  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   GeolocatorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("GeolocatorWindows"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
   firebase_auth
   firebase_core
+  flutter_secure_storage_windows
   geolocator_windows
   permission_handler_windows
   url_launcher_windows


### PR DESCRIPTION
## #️⃣ 연관된 이슈
.

## 🛠️ 작업 내용
### JWT 토큰 관리

1. JWT 토큰을 관리하기 위한 서비스 구현
    - `bannabe\lib\core\services\token_service.dart`
    - `flutter_secure_storage: ^9.0.0` 패키지 추가
    - `TokenService` 클래스 구현 → 액세스 토큰과 리프레시 토큰 관리 (저장, 가져오기, 삭제, 존재 여부 확인)
2. Dio 인터셉터 구현 → 토큰 관리와 401 에러 처리
    - `bannabe\lib\core\services\api_service.dart`
    - `ApiService` 클래스 구현
        - API 요청 시 토큰을 자동으로 추가
        - 토큰 만료 시 리프레시 토큰을 사용하여 새 토큰 발급
    - 액세스 토큰이 있으면 헤더에 추가
    - 401 에러 처리 (토큰 만료)
        - 리프레시 토큰이 있는지 확인
            - 리프레시 토큰으로 새 액세스 토큰 요청
            - 새 토큰 저장
            - 원래 요청 재시도
        - 리프레시 토큰도 만료되었거나 없는 경우, 로그인 페이지로 리디렉션
            - `_navigateToLogin();`
3. AuthService를 수정하여 JWT 토큰 처리
    - `bannabe\lib\core\services\auth_service.dart`
    - `AuthService` 클래스 수정
        - 로그인 시 JWT 토큰(액세스 토큰 및 리프레시 토큰)을 flutter_secure_storage에 저장
        - 로그아웃 시 토큰을 삭제

### 사용자 정보 표시

- 마이페이지에서 로그인한 사용자의 프로필 이미지, 닉네임, 이메일 표시
- 페이지가 로드될 때 사용자 프로필 정보를 가져옴
- AuthService를 리스닝하여 사용자 정보 변경 시 UI 업데이트
- 프로필 이미지 처리
    - `errorBuilder` 콜백을 통해 이미지 로딩 실패 시 기본 이미지(`assets/images/profile.jpg`)를 표시
    - 프로필 이미지가 없는 경우에도 동일한 기본 이미지를 표시

### 하단 네비게이션 바 수정

- 마이페이지 탭을 눌렀을 때 로그인 상태에 따라 다른 화면이 표시되도록
- AuthService의 isAuthenticated 속성을 통해 인증 상태 확인
    - _currentUser가 null이 아닌지를 확인

### 닉네임 변경 API 연동

- `변경하기`  버튼 클릭 시 `/v1/users/me/nickname`로 `nickname`을 RequestBody에 담아 서버로 Patch 요청

### 비밀번호 변경 API 연동

- 현재 비밀번호, 변경할 비밀번호, 비밀번호 확인 입력 후 확인 클릭
    - 변경할 비밀번호(`newPassword`), 비밀번호 확인(`newPasswordConfirm`) 일치하면, `currentPassword`, `newPassword`, `newPasswordConfirm`을 `/v1/users/me/password`로RequestBody에 담아 put 요청

## 💬 To Other
- 패키지를 추가했으니 앱을 실행하기 전에 패키지를 설치해야 합니다.
- 터미널에서 다음 명령어를 실행해야 합니다.
```
flutter clean  // 기존 캐시 제거
flutter pub get  // 새로운 패키지 설치
```