### PR TITLE
Feature: 프로필 이미지 및 스테이션 API 연동

### DIFF
--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -123,9 +123,9 @@ class ApiService {
   }
 
   // POST 요청
-  Future<Response> post(String path, {dynamic data}) async {
+  Future<Response> post(String path, {dynamic data, Options? options}) async {
     try {
-      return await _dio.post(path, data: data);
+      return await _dio.post(path, data: data, options: options);
     } on DioException {
       rethrow;
     }

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -14,8 +14,9 @@ class ApiService {
     _dio = Dio(
       BaseOptions(
         baseUrl: _baseUrl,
-        connectTimeout: const Duration(seconds: 5),
-        receiveTimeout: const Duration(seconds: 10),
+        connectTimeout: const Duration(seconds: 30),
+        receiveTimeout: const Duration(seconds: 30),
+        sendTimeout: const Duration(seconds: 30),
         headers: {
           'Content-Type': 'application/json',
           'Accept': 'application/json',
@@ -27,6 +28,11 @@ class ApiService {
     _dio.interceptors.add(
       InterceptorsWrapper(
         onRequest: (options, handler) async {
+          // 스테이션 관련 API는 토큰 체크 스킵
+          if (options.path.startsWith('/stations')) {
+            return handler.next(options);
+          }
+
           // 액세스 토큰이 있으면 헤더에 추가
           final accessToken = await TokenService.instance.getAccessToken();
 

--- a/lib/features/map/views/map_view.dart
+++ b/lib/features/map/views/map_view.dart
@@ -7,8 +7,8 @@ import '../../../core/widgets/bottom_navigation_bar.dart';
 import '../../../core/widgets/loading_animation.dart';
 import '../viewmodels/map_viewmodel.dart';
 import '../../../app/routes.dart';
-import '../../../features/rental/views/rental_detail_view.dart';
 import '../../../core/services/storage_service.dart';
+import '../../../core/services/token_service.dart';
 
 class MapView extends StatelessWidget {
   const MapView({super.key});
@@ -26,6 +26,7 @@ class _MapContent extends StatelessWidget {
   _MapContent();
 
   final _storageService = StorageService.instance;
+  final _tokenService = TokenService.instance;
 
   @override
   Widget build(BuildContext context) {
@@ -34,10 +35,18 @@ class _MapContent extends StatelessWidget {
         title: const Text('주변 스테이션'),
         centerTitle: true,
         actions: [
-          IconButton(
-            icon: const Icon(Icons.favorite),
-            onPressed: () {
-              _showFavoriteStations(context);
+          FutureBuilder<String?>(
+            future: _tokenService.getAccessToken(),
+            builder: (context, snapshot) {
+              if (snapshot.hasData && snapshot.data != null) {
+                return IconButton(
+                  icon: const Icon(Icons.favorite),
+                  onPressed: () {
+                    _showFavoriteStations(context);
+                  },
+                );
+              }
+              return const SizedBox.shrink();
             },
           ),
         ],
@@ -191,27 +200,36 @@ class _MapContent extends StatelessWidget {
                               ),
                               Row(
                                 children: [
-                                  IconButton(
-                                    padding: EdgeInsets.zero,
-                                    icon: Icon(
-                                      viewModel.isStationFavorite(
-                                              viewModel.selectedStation!)
-                                          ? Icons.favorite
-                                          : Icons.favorite_border,
-                                      color: AppColors.primary,
-                                    ),
-                                    onPressed: () {
-                                      try {
-                                        viewModel.toggleFavorite(
-                                            viewModel.selectedStation!);
-                                      } catch (e) {
-                                        ScaffoldMessenger.of(context)
-                                            .showSnackBar(
-                                          SnackBar(
-                                            content: Text(e.toString()),
+                                  FutureBuilder<String?>(
+                                    future: _tokenService.getAccessToken(),
+                                    builder: (context, snapshot) {
+                                      if (snapshot.hasData &&
+                                          snapshot.data != null) {
+                                        return IconButton(
+                                          padding: EdgeInsets.zero,
+                                          icon: Icon(
+                                            viewModel.isStationFavorite(
+                                                    viewModel.selectedStation!)
+                                                ? Icons.favorite
+                                                : Icons.favorite_border,
+                                            color: AppColors.primary,
                                           ),
+                                          onPressed: () {
+                                            try {
+                                              viewModel.toggleFavorite(
+                                                  viewModel.selectedStation!);
+                                            } catch (e) {
+                                              ScaffoldMessenger.of(context)
+                                                  .showSnackBar(
+                                                SnackBar(
+                                                  content: Text(e.toString()),
+                                                ),
+                                              );
+                                            }
+                                          },
                                         );
                                       }
+                                      return const SizedBox.shrink();
                                     },
                                   ),
                                   IconButton(

--- a/lib/features/mypage/views/edit_profile_view.dart
+++ b/lib/features/mypage/views/edit_profile_view.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:dio/dio.dart';
 import '../../../core/constants/app_colors.dart';
 import '../../../core/constants/app_theme.dart';
 import '../../../core/services/auth_service.dart';
@@ -21,6 +22,7 @@ class _EditProfileViewState extends State<EditProfileView> {
   File? _selectedImage;
   String? _error;
   String? _success;
+  bool _isLoading = false;
 
   @override
   void initState() {
@@ -52,14 +54,10 @@ class _EditProfileViewState extends State<EditProfileView> {
     }
 
     try {
-      // 카메라 앱 열기
-      await _picker.pickImage(source: ImageSource.camera);
-
-      // 이미지 선택 후 처리는 추후 구현 예정
-      setState(() {
-        _success = '카메라 촬영 완료. 이미지 처리 기능 추후 구현 예정';
-        _error = null;
-      });
+      final XFile? image = await _picker.pickImage(source: ImageSource.camera);
+      if (image != null) {
+        await _uploadImage(File(image.path));
+      }
     } catch (e) {
       setState(() {
         _error = '카메라 접근 중 오류가 발생했습니다: ${e.toString()}';
@@ -81,14 +79,10 @@ class _EditProfileViewState extends State<EditProfileView> {
     }
 
     try {
-      // 갤러리 앱 열기
-      await _picker.pickImage(source: ImageSource.gallery);
-
-      // 이미지 선택 후 처리는 추후 구현 예정
-      setState(() {
-        _success = '갤러리에서 이미지 선택 완료. 이미지 처리 기능 추후 구현 예정';
-        _error = null;
-      });
+      final XFile? image = await _picker.pickImage(source: ImageSource.gallery);
+      if (image != null) {
+        await _uploadImage(File(image.path));
+      }
     } catch (e) {
       setState(() {
         _error = '갤러리 접근 중 오류가 발생했습니다: ${e.toString()}';
@@ -97,13 +91,79 @@ class _EditProfileViewState extends State<EditProfileView> {
     }
   }
 
+  // 이미지 업로드 처리
+  Future<void> _uploadImage(File imageFile) async {
+    try {
+      setState(() {
+        _isLoading = true;
+        _error = null;
+        _success = null;
+      });
+
+      // PreSigned URL 조회
+      final preSignedUrl =
+          await AuthService.instance.getProfileImagePreSignedUrl();
+
+      // 이미지 파일을 PreSigned URL로 업로드
+      final dio = Dio();
+      await dio.put(
+        preSignedUrl,
+        data: await imageFile.readAsBytes(),
+        options: Options(
+          headers: {
+            'Content-Type': 'image/jpeg',
+          },
+        ),
+      );
+
+      // 이미지 URL 추출 (PreSigned URL에서 파일 경로 추출)
+      final imageUrl = preSignedUrl.split('?')[0];
+
+      // 프로필 이미지 업데이트
+      await AuthService.instance.updateProfileImage(imageUrl);
+
+      setState(() {
+        _success = '프로필 이미지가 성공적으로 업데이트되었습니다.';
+        _error = null;
+      });
+    } catch (e) {
+      setState(() {
+        _error = '이미지 업로드 실패: ${e.toString()}';
+        _success = null;
+      });
+    } finally {
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
   // 이미지 삭제
-  void _deleteImage() {
-    setState(() {
-      _selectedImage = null;
-      _success = '이미지 삭제 기능 추후 구현 예정';
-      _error = null;
-    });
+  Future<void> _deleteImage() async {
+    try {
+      setState(() {
+        _isLoading = true;
+        _error = null;
+        _success = null;
+      });
+
+      // 프로필 이미지 업데이트 (null로 설정)
+      await AuthService.instance.updateProfileImage('');
+
+      setState(() {
+        _success = '프로필 이미지가 삭제되었습니다.';
+        _error = null;
+      });
+    } catch (e) {
+      setState(() {
+        _error = '이미지 삭제 실패: ${e.toString()}';
+        _success = null;
+      });
+    } finally {
+      setState(() {
+        _isLoading = false;
+      });
+    }
   }
 
   // 이미지 변경 옵션 보여주기
@@ -176,207 +236,219 @@ class _EditProfileViewState extends State<EditProfileView> {
         title: const Text('프로필 관리'),
         centerTitle: true,
       ),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(16.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              // 1. 상단 프로필 정보 영역
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
+      body: Stack(
+        children: [
+          SafeArea(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  // 프로필 이미지
-                  Stack(
+                  // 1. 상단 프로필 정보 영역
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
-                      Container(
-                        width: 80,
-                        height: 80,
-                        decoration: BoxDecoration(
-                          shape: BoxShape.circle,
-                          border: Border.all(
-                            color: Colors.white,
-                            width: 2,
-                          ),
-                        ),
-                        child: ClipOval(
-                          child: user?.profileImageUrl != null &&
-                                  user!.profileImageUrl!.isNotEmpty
-                              ? Image(
-                                  image:
-                                      user.profileImageUrl!.startsWith('http')
+                      // 프로필 이미지
+                      Stack(
+                        children: [
+                          Container(
+                            width: 80,
+                            height: 80,
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              border: Border.all(
+                                color: Colors.white,
+                                width: 2,
+                              ),
+                            ),
+                            child: ClipOval(
+                              child: user?.profileImageUrl != null &&
+                                      user!.profileImageUrl!.isNotEmpty
+                                  ? Image(
+                                      image: user.profileImageUrl!
+                                              .startsWith('http')
                                           ? NetworkImage(user.profileImageUrl!)
                                           : AssetImage(user.profileImageUrl!)
                                               as ImageProvider,
-                                  fit: BoxFit.cover,
-                                  errorBuilder: (context, error, stackTrace) {
-                                    return Image.asset(
+                                      fit: BoxFit.cover,
+                                      errorBuilder:
+                                          (context, error, stackTrace) {
+                                        return Image.asset(
+                                          'assets/images/profile.jpg',
+                                          fit: BoxFit.cover,
+                                        );
+                                      },
+                                    )
+                                  : Image.asset(
                                       'assets/images/profile.jpg',
                                       fit: BoxFit.cover,
-                                    );
-                                  },
-                                )
-                              : Image.asset(
-                                  'assets/images/profile.jpg',
-                                  fit: BoxFit.cover,
-                                ),
+                                    ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(width: 16),
+                      // 사용자 정보 (이름, 이메일)
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              user?.nickname ?? '사용자',
+                              style: const TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              user?.email ?? '',
+                              style: TextStyle(
+                                fontSize: 14,
+                                color: Colors.grey[600],
+                              ),
+                            ),
+                          ],
                         ),
                       ),
                     ],
                   ),
-                  const SizedBox(width: 16),
-                  // 사용자 정보 (이름, 이메일)
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          user?.nickname ?? '사용자',
-                          style: const TextStyle(
-                            fontSize: 18,
-                            fontWeight: FontWeight.bold,
+
+                  const SizedBox(height: 32),
+
+                  // 2. 프로필 이미지 변경 및 닉네임 변경 버튼
+                  Row(
+                    children: [
+                      // 프로필 이미지 변경 버튼
+                      Expanded(
+                        child: ElevatedButton.icon(
+                          onPressed: _showImageOptions,
+                          icon: const Icon(Icons.photo_camera),
+                          label: const Text('이미지 변경'),
+                          style: ElevatedButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(vertical: 12),
                           ),
                         ),
-                        const SizedBox(height: 4),
-                        Text(
-                          user?.email ?? '',
-                          style: TextStyle(
-                            fontSize: 14,
+                      ),
+                      const SizedBox(width: 12),
+                      // 닉네임 변경 버튼
+                      Expanded(
+                        child: ElevatedButton.icon(
+                          onPressed: _navigateToNicknameChange,
+                          icon: const Icon(Icons.edit),
+                          label: const Text('닉네임 변경'),
+                          style: ElevatedButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(vertical: 12),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+
+                  const SizedBox(height: 32),
+
+                  // 3. 비밀번호 변경 페이지로 이동하는 필드
+                  InkWell(
+                    onTap: _navigateToPasswordChange,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                          vertical: 16, horizontal: 12),
+                      decoration: BoxDecoration(
+                        border: Border.all(color: AppColors.lightGrey),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          const Text(
+                            '비밀번호 변경',
+                            style: TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                          Icon(
+                            Icons.arrow_forward_ios,
+                            size: 16,
                             color: Colors.grey[600],
                           ),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
+
+                  const SizedBox(height: 16),
+
+                  // 4. 북마크한 스테이션 관리 페이지로 이동하는 필드
+                  InkWell(
+                    onTap: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (context) => const BookmarkedStationsView(),
+                        ),
+                      );
+                    },
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                          vertical: 16, horizontal: 12),
+                      decoration: BoxDecoration(
+                        border: Border.all(color: AppColors.lightGrey),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          const Text(
+                            '북마크한 스테이션 관리',
+                            style: TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                          Icon(
+                            Icons.arrow_forward_ios,
+                            size: 16,
+                            color: Colors.grey[600],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+
+                  // 오류 및 성공 메시지 표시
+                  if (_error != null) ...[
+                    const SizedBox(height: 16),
+                    Text(
+                      _error!,
+                      style: AppTheme.bodyMedium.copyWith(
+                        color: AppColors.error,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+
+                  if (_success != null) ...[
+                    const SizedBox(height: 16),
+                    Text(
+                      _success!,
+                      style: AppTheme.bodyMedium.copyWith(
+                        color: AppColors.success,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
                 ],
               ),
-
-              const SizedBox(height: 32),
-
-              // 2. 프로필 이미지 변경 및 닉네임 변경 버튼
-              Row(
-                children: [
-                  // 프로필 이미지 변경 버튼
-                  Expanded(
-                    child: ElevatedButton.icon(
-                      onPressed: _showImageOptions,
-                      icon: const Icon(Icons.photo_camera),
-                      label: const Text('이미지 변경'),
-                      style: ElevatedButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  // 닉네임 변경 버튼
-                  Expanded(
-                    child: ElevatedButton.icon(
-                      onPressed: _navigateToNicknameChange,
-                      icon: const Icon(Icons.edit),
-                      label: const Text('닉네임 변경'),
-                      style: ElevatedButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-
-              const SizedBox(height: 32),
-
-              // 3. 비밀번호 변경 페이지로 이동하는 필드
-              InkWell(
-                onTap: _navigateToPasswordChange,
-                child: Container(
-                  padding:
-                      const EdgeInsets.symmetric(vertical: 16, horizontal: 12),
-                  decoration: BoxDecoration(
-                    border: Border.all(color: AppColors.lightGrey),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      const Text(
-                        '비밀번호 변경',
-                        style: TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w500,
-                        ),
-                      ),
-                      Icon(
-                        Icons.arrow_forward_ios,
-                        size: 16,
-                        color: Colors.grey[600],
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-
-              const SizedBox(height: 16),
-
-              // 4. 북마크한 스테이션 관리 페이지로 이동하는 필드
-              InkWell(
-                onTap: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (context) => const BookmarkedStationsView(),
-                    ),
-                  );
-                },
-                child: Container(
-                  padding:
-                      const EdgeInsets.symmetric(vertical: 16, horizontal: 12),
-                  decoration: BoxDecoration(
-                    border: Border.all(color: AppColors.lightGrey),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      const Text(
-                        '북마크한 스테이션 관리',
-                        style: TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w500,
-                        ),
-                      ),
-                      Icon(
-                        Icons.arrow_forward_ios,
-                        size: 16,
-                        color: Colors.grey[600],
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-
-              // 오류 및 성공 메시지 표시
-              if (_error != null) ...[
-                const SizedBox(height: 16),
-                Text(
-                  _error!,
-                  style: AppTheme.bodyMedium.copyWith(
-                    color: AppColors.error,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-              ],
-
-              if (_success != null) ...[
-                const SizedBox(height: 16),
-                Text(
-                  _success!,
-                  style: AppTheme.bodyMedium.copyWith(
-                    color: AppColors.success,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-              ],
-            ],
+            ),
           ),
-        ),
+          if (_isLoading)
+            Container(
+              color: Colors.black.withOpacity(0.3),
+              child: const Center(
+                child: CircularProgressIndicator(),
+              ),
+            ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#5

## 🛠️ 작업 내용
### 프로필 이미지 변경 API 연동
- S3 PreSignedURL 조회
- 프로필 이미지 변경

### 스테이션 관련 API 수정
- /vi/stations API는 토큰 체크 스킵

### MapView에서 토큰 기반 북마크 기능 제어
- 로그인하지 않은 사용자는 북마크 조회/추가/삭제 불가하도록 처리
	- 사용자 토큰 유무에 따라 북마크 UI 및 기능 활성/비활성
	- MapView에서 북마크 토글 기능 수정
		- 이미 북마크된 스테이션을 클릭하면 북마크 삭제

## 💬 To Other
사용자가 프로필 이미지 삭제 했을 때 (=기본 이미지로 돌아가고 싶을 때) 처리 방법도 있을까요?