### PR TITLE
Feat: 결제 플로우 개선 및 완료 화면 구현

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="bannabee" />
+                <data android:scheme="bannabe" />
             </intent-filter>
 
         </activity>

--- a/lib/core/widgets/bottom_navigation_bar.dart
+++ b/lib/core/widgets/bottom_navigation_bar.dart
@@ -38,7 +38,10 @@ class AppBottomNavigationBar extends StatelessWidget {
           case 3:
             final hasToken = await TokenService.instance.hasAccessToken();
             if (!hasToken) {
-              Navigator.of(context).pushReplacementNamed(Routes.login);
+              Navigator.of(context).pushNamedAndRemoveUntil(
+                Routes.login,
+                (route) => false,
+              );
             } else {
               Navigator.of(context).pushReplacementNamed(Routes.mypage);
             }

--- a/lib/data/models/rental_success_simple_response.dart
+++ b/lib/data/models/rental_success_simple_response.dart
@@ -1,0 +1,22 @@
+class RentalSuccessSimpleResponse {
+  final int amount;
+  final String itemName;
+  final int rentalTime;
+  final String stationName;
+
+  RentalSuccessSimpleResponse({
+    required this.amount,
+    required this.itemName,
+    required this.rentalTime,
+    required this.stationName,
+  });
+
+  factory RentalSuccessSimpleResponse.fromJson(Map<String, dynamic> json) {
+    return RentalSuccessSimpleResponse(
+      amount: json['totalAmount'] as int,
+      itemName: json['itemName'] as String,
+      rentalTime: json['rentalTime'] as int,
+      stationName: json['rentalStationName'] as String,
+    );
+  }
+}

--- a/lib/features/payment/views/payment_view.dart
+++ b/lib/features/payment/views/payment_view.dart
@@ -229,10 +229,23 @@ class _PaymentViewState extends State<PaymentView> {
       );
 
       if (result != null && mounted) {
-        Navigator.of(context).pushReplacementNamed(
-          Routes.paymentComplete,
-          arguments: rental,
-        );
+        print('결제 결과: $result');
+        if (result.startsWith('failure:')) {
+          // 결제 실패 처리
+          final message = result.substring(8);
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(message),
+              backgroundColor: AppColors.error,
+            ),
+          );
+        } else {
+          // 결제 성공 처리
+          Navigator.of(context).pushReplacementNamed(
+            Routes.paymentComplete,
+            arguments: result,
+          );
+        }
       }
     } catch (e) {
       if (mounted) {

--- a/lib/features/payment/views/payment_view.dart
+++ b/lib/features/payment/views/payment_view.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:dio/dio.dart';
 import '../../../core/constants/app_theme.dart';
 import '../../../core/constants/app_colors.dart';
 import '../../../data/models/rental.dart';
@@ -9,7 +8,6 @@ import '../../../app/routes.dart';
 import '../../../core/services/token_service.dart';
 import '../../rental/viewmodels/qr_scan_viewmodel.dart';
 import '../../payment/views/payment_webview.dart';
-import '../../../data/services/payment_service.dart';
 
 class PaymentView extends StatefulWidget {
   final Map<String, dynamic> arguments;
@@ -27,7 +25,6 @@ class _PaymentViewState extends State<PaymentView> {
   late final Rental rental;
   late final PaymentCalculateResponse paymentCalculation;
   late final RentalItemResponse? rentalItemResponse;
-  late final PaymentService _paymentService;
   bool agreedToTerms = false;
 
   @override
@@ -38,12 +35,6 @@ class _PaymentViewState extends State<PaymentView> {
         widget.arguments['paymentCalculation'] as PaymentCalculateResponse;
     rentalItemResponse =
         widget.arguments['rentalItemResponse'] as RentalItemResponse?;
-    _paymentService = PaymentService(Dio(BaseOptions(
-      baseUrl: "http://10.0.2.2:8080/v1",
-      connectTimeout: const Duration(seconds: 30),
-      receiveTimeout: const Duration(seconds: 30),
-      sendTimeout: const Duration(seconds: 30),
-    )));
   }
 
   Future<void> _launchKakaoPayLink() async {
@@ -226,32 +217,18 @@ class _PaymentViewState extends State<PaymentView> {
         return;
       }
 
-      // 결제창 호출 API 호출
-      final response = await _paymentService.createCheckout(
-        rentalItemToken: rental.token,
-        rentalTime: paymentCalculation.rentalTime,
-        amount: paymentCalculation.amount,
-        paymentType: PaymentType.RENT,
-        orderName: rental.name,
-      );
-
-      if (!mounted) return;
-
-      final result = await Navigator.of(context).push<bool>(
+      final result = await Navigator.of(context).push<String>(
         MaterialPageRoute(
           builder: (context) => PaymentWebView(
-            checkoutUrl: response.htmlContent,
             accessToken: accessToken,
-            paymentService: _paymentService,
-            orderId: response.orderId,
-            orderName: rental.name,
-            amount: paymentCalculation.amount,
-            customerKey: response.customerKey,
+            rentalItemToken: rental.token,
+            rentalTime: paymentCalculation.rentalTime.toString(),
+            paymentType: 'RENT',
           ),
         ),
       );
 
-      if (result == true && mounted) {
+      if (result != null && mounted) {
         Navigator.of(context).pushReplacementNamed(
           Routes.paymentComplete,
           arguments: rental,

--- a/lib/features/payment/views/payment_webview.dart
+++ b/lib/features/payment/views/payment_webview.dart
@@ -1,5 +1,9 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class PaymentWebView extends StatefulWidget {
   final String accessToken;
@@ -41,16 +45,113 @@ class _PaymentWebViewState extends State<PaymentWebView> {
               isLoading = false;
             });
             _controller.runJavaScript('''
-              sessionStorage.setItem('accessToken', '${widget.accessToken}');
+              try {
+                sessionStorage.setItem('accessToken', '${widget.accessToken}');
+              } catch (e) {
+                console.error('sessionStorage 접근 오류:', e);
+              }
             ''');
           },
-          onNavigationRequest: (NavigationRequest request) {
-            if (request.url.startsWith('bannabe://')) {
+          onNavigationRequest: (NavigationRequest request) async {
+            if (request.url.contains('/v1/payments/success')) {
               final uri = Uri.parse(request.url);
-              if (uri.host == 'payment-success') {
+              final paymentKey = uri.queryParameters['paymentKey'];
+              final amount = uri.queryParameters['amount'];
+              final orderId = uri.queryParameters['orderId'];
+
+              if (paymentKey != null && amount != null && orderId != null) {
+                // ✅ Flutter에서 HTTP 요청 보내기
+                try {
+                  final response = await http.post(
+                    Uri.parse('http://10.0.2.2:8080/v1/payments/confirm'),
+                    headers: {
+                      'Content-Type': 'application/json',
+                      'Authorization': 'Bearer ${widget.accessToken}',
+                    },
+                    body: jsonEncode({
+                      'paymentKey': paymentKey,
+                      'amount': int.parse(amount),
+                      'orderId': orderId,
+                    }),
+                  );
+
+                  final result = jsonDecode(response.body);
+                  if (result['success'] == true) {
+                    final rentalHistoryToken =
+                        result['data']['rentalHistoryToken'];
+                    Navigator.of(context).pop(rentalHistoryToken);
+                  } else {
+                    Navigator.of(context).pop('failure:${result['message']}');
+                  }
+                } catch (e) {
+                  Navigator.of(context).pop('failure:결제 처리 중 오류가 발생했습니다.');
+                }
+
+                return NavigationDecision.prevent;
+              }
+            } else if (request.url.contains('/v1/payments/failure')) {
+              final uri = Uri.parse(request.url);
+              final message = uri.queryParameters['message'] ?? '결제가 실패했습니다.';
+              Navigator.of(context).pop('failure:$message');
+              return NavigationDecision.prevent;
+            } else if (request.url.contains('/v1/payments/success')) {
+              final uri = Uri.parse(request.url);
+              final rentalHistoryToken =
+                  uri.queryParameters['rentalHistoryToken'];
+              if (rentalHistoryToken != null) {
+                Navigator.of(context).pop(rentalHistoryToken);
+                return NavigationDecision.prevent;
+              }
+            } else if (request.url.startsWith('intent://')) {
+              final uri = Uri.parse(request.url);
+              if (uri.host == 'pay') {
+                final payToken = uri.queryParameters['payToken'];
+                if (payToken != null) {
+                  final tossUrl = Uri(
+                    scheme: 'supertoss',
+                    host: 'pay',
+                    queryParameters: {
+                      'payToken': payToken,
+                      'deviceType': 'mobile',
+                      'isTossApp': 'false',
+                      'appPayVersion': '2.0',
+                    },
+                  );
+                  try {
+                    final result = await launchUrl(
+                      tossUrl,
+                      mode: LaunchMode.externalApplication,
+                    );
+                    if (!result) {
+                      // 토스 앱이 설치되어 있지 않은 경우
+                      final marketUrl =
+                          Uri.parse('market://details?id=viva.republica.toss');
+                      await launchUrl(
+                        marketUrl,
+                        mode: LaunchMode.externalApplication,
+                      );
+                    }
+                  } catch (e) {
+                    print('토스 앱 실행 오류: $e');
+                    // Play Store로 이동
+                    final playStoreUrl = Uri.parse(
+                        'https://play.google.com/store/apps/details?id=viva.republica.toss');
+                    await launchUrl(
+                      playStoreUrl,
+                      mode: LaunchMode.externalApplication,
+                    );
+                  }
+                  return NavigationDecision.prevent;
+                }
+              } else if (uri.host == 'payment-success') {
                 final rentalHistoryToken =
                     uri.queryParameters['rentalHistoryToken'];
-                Navigator.of(context).pop(rentalHistoryToken);
+                if (rentalHistoryToken != null) {
+                  Navigator.of(context).pop(rentalHistoryToken);
+                }
+              } else if (uri.host == 'payment-failure') {
+                final message = uri.queryParameters['message'];
+                Navigator.of(context).pop('failure:$message');
               }
               return NavigationDecision.prevent;
             }

--- a/lib/features/payment/views/payment_webview.dart
+++ b/lib/features/payment/views/payment_webview.dart
@@ -1,25 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
-import '../../../data/services/payment_service.dart';
 
 class PaymentWebView extends StatefulWidget {
-  final String checkoutUrl; // HTML 컨텐츠
   final String accessToken;
-  final PaymentService paymentService;
-  final String orderId;
-  final String orderName;
-  final int amount;
-  final String customerKey;
+  final String rentalItemToken;
+  final String rentalTime;
+  final String paymentType;
 
   const PaymentWebView({
     super.key,
-    required this.checkoutUrl,
     required this.accessToken,
-    required this.paymentService,
-    required this.orderId,
-    required this.orderName,
-    required this.amount,
-    required this.customerKey,
+    required this.rentalItemToken,
+    required this.rentalTime,
+    required this.paymentType,
   });
 
   @override
@@ -39,81 +32,54 @@ class _PaymentWebViewState extends State<PaymentWebView> {
       ..setNavigationDelegate(
         NavigationDelegate(
           onPageStarted: (String url) {
-            print('[DEBUG] WebView 페이지 로드 시작: $url');
             setState(() {
               isLoading = true;
             });
           },
           onPageFinished: (String url) {
-            print('[DEBUG] WebView 페이지 로드 완료: $url');
             setState(() {
               isLoading = false;
             });
+            _controller.runJavaScript('''
+              sessionStorage.setItem('accessToken', '${widget.accessToken}');
+            ''');
           },
           onNavigationRequest: (NavigationRequest request) {
-            print('[DEBUG] WebView 네비게이션 요청: ${request.url}');
-            if (request.url.contains('test-success')) {
-              Navigator.of(context).pop(true);
+            if (request.url.startsWith('bannabe://')) {
+              final uri = Uri.parse(request.url);
+              if (uri.host == 'payment-success') {
+                final rentalHistoryToken =
+                    uri.queryParameters['rentalHistoryToken'];
+                Navigator.of(context).pop(rentalHistoryToken);
+              }
               return NavigationDecision.prevent;
             }
             return NavigationDecision.navigate;
           },
           onWebResourceError: (WebResourceError error) {
             print('[ERROR] WebView 에러: ${error.description}');
-            print('[ERROR] WebView 에러 코드: ${error.errorCode}');
-            print('[ERROR] WebView 에러 타입: ${error.errorType}');
           },
         ),
       );
 
-    // HTML 컨텐츠 수정
-    String modifiedHtml = widget.checkoutUrl;
-    print('[DEBUG] 원본 HTML 길이: ${modifiedHtml.length}');
+    final paymentUrl = Uri(
+      scheme: 'http',
+      host: '10.0.2.2',
+      port: 8080,
+      path: '/v1/payments/checkout',
+      queryParameters: {
+        'rentalItemToken': widget.rentalItemToken,
+        'rentalTime': widget.rentalTime,
+        'paymentType': widget.paymentType,
+      },
+    ).toString();
 
-    // localhost를 10.0.2.2로 변경
-    modifiedHtml = modifiedHtml.replaceAll('localhost', '10.0.2.2');
-    print('[DEBUG] localhost 변경 후 HTML 길이: ${modifiedHtml.length}');
-
-    // 토스 페이먼츠 결제창 설정 수정
-    modifiedHtml = modifiedHtml.replaceAll('async function requestPayment() {',
-        '''async function requestPayment() {
-        const successUrl = "https://docs.tosspayments.com/guides/payment/test-success";
-        const failUrl = "https://docs.tosspayments.com/guides/payment/test-fail";
-
-        // View Model 데이터 선언
-        const clientKey = "test_ck_PBal2vxj81yE5wYp9vqk85RQgOAN";
-        const customerKey = "${widget.customerKey}";
-        const orderId = "${widget.orderId}";
-        const orderName = "${widget.orderName}";
-
-        try {
-          const tossPayments = TossPayments(clientKey);
-          const paymentWidget = tossPayments.payment({
-            customerKey: customerKey
-          });
-
-          await paymentWidget.requestPayment({
-            method: "CARD",
-            amount,
-            orderId: orderId,
-            orderName: orderName,
-            successUrl: successUrl,
-            failUrl: failUrl
-          });
-        } catch (error) {
-          console.error('결제 요청 실패:', error);
-        }''');
-    print('[DEBUG] 결제창 설정 변경 후 HTML 길이: ${modifiedHtml.length}');
-
-    // HTML이 완전한지 확인
-    if (!modifiedHtml.contains('</html>')) {
-      print('[ERROR] HTML이 완전하지 않습니다!');
-    }
-
-    print('[DEBUG] 최종 HTML:');
-    print(modifiedHtml);
-
-    _controller.loadHtmlString(modifiedHtml);
+    _controller.loadRequest(
+      Uri.parse(paymentUrl),
+      headers: {
+        'Authorization': 'Bearer ${widget.accessToken}',
+      },
+    );
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -104,7 +104,8 @@ class MyApp extends StatelessWidget {
                   as Map<String, dynamic>,
             ),
         Routes.paymentComplete: (context) => PaymentCompleteView(
-              rental: ModalRoute.of(context)!.settings.arguments as Rental,
+              rentalHistoryToken:
+                  ModalRoute.of(context)!.settings.arguments as String,
             ),
         Routes.mypage: (context) => const MyPageView(),
         Routes.editProfile: (context) => const EditProfileView(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,6 @@ import 'core/constants/app_colors.dart';
 import 'core/services/auth_service.dart';
 import 'core/services/api_service.dart';
 import 'data/models/rental.dart';
-import 'data/models/accessory.dart';
 import 'features/auth/views/login_view.dart';
 import 'features/auth/views/signup_complete_view.dart';
 import 'features/auth/views/signup_view.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -353,7 +353,7 @@ packages:
     source: hosted
     version: "0.2.3"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   image_picker: ^1.0.7
   flutter_svg: ^2.0.9
   webview_flutter: ^4.7.0
+  http: ^1.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
x

## 🛠️ 작업 내용

### 1. 결제 프로세스 개선
- WebView에서  
  - 액세스 토큰을 `sessionStorage`에 저장  
  - SSR 방식으로 결제 페이지 렌더링
- `PaymentService` 제거 (불필요한 API 호출 제거)
- 커스텀 스킴 `bannabe://` 설정

### 2. 결제 완료 화면 개선
- 대여 정보 조회 API 연동
- 로딩 상태 및 에러 처리 추가
- UI/UX 개선

### 3. API 응답 모델 추가
- `RentalSuccessSimpleResponse` 모델 추가
- 결제/대여 완료 정보 표시 구현


## 🖼️ 스크린샷  
![image](https://github.com/user-attachments/assets/1af075f7-47b6-4cee-9ffb-06d32e003a96)


## 💬 To Other
- QR 스캔 시 **이미 대여 중인 물품**에 대한 처리 필요  
  → 현재는 404 에러가 그대로 출력되고 있음